### PR TITLE
Schedule devices update right after it's added

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -45,10 +45,6 @@ class TahomaSensor(TahomaDevice, Entity):
 
         super().__init__(tahoma_device, controller)
 
-    async def async_added_to_hass(self):
-        await super().async_added_to_hass()
-        self.schedule_update_ha_state(True)
-
     @property
     def state(self):
         """Return the name of the sensor."""

--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -45,6 +45,10 @@ class TahomaSensor(TahomaDevice, Entity):
 
         super().__init__(tahoma_device, controller)
 
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self.schedule_update_ha_state(True)
+
     @property
     def state(self):
         """Return the name of the sensor."""

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -21,6 +21,10 @@ class TahomaDevice(Entity):
         self._name = self.tahoma_device.label
         self.controller = controller
 
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self.schedule_update_ha_state(True)
+
     @property
     def name(self):
         """Return the name of the device."""


### PR DESCRIPTION
Update the sensors right after it's been added instead of waiting 1 min for the standard update.