### PR TITLE
Remove lock variables from Cover device state attributes

### DIFF
--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -89,9 +89,6 @@ TAHOMA_SENSOR_DEVICE_CLASSES = {
 # TaHoma Attributes
 ATTR_MEM_POS = "memorized_position"
 ATTR_RSSI_LEVEL = "rssi_level"
-ATTR_LOCK_START_TS = "lock_start_ts"
-ATTR_LOCK_END_TS = "lock_end_ts"
-ATTR_LOCK_LEVEL = "lock_level"
 ATTR_LOCK_ORIG = "lock_originator"
 
 # TaHoma internal device states

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -228,12 +228,12 @@ class TahomaCover(TahomaDevice, CoverEntity):
     @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
-        icon = None
         if self._lock_timer > 0:
-            icon = "mdi:lock-alert"
             if self._lock_originator == "wind":
-                icon = "mdi:weather-windy"
-        return icon
+                return "mdi:weather-windy"
+            else:
+                return "mdi:lock-alert"
+        return None
 
     def open_cover(self, **kwargs):
         """Open the cover."""


### PR DESCRIPTION
Some `_lock_xxx` variables was only used fo within `device_state_attributes` which is IMO useless. Removing them, we once again ease the code with useless boilerplate.