### PR TITLE
Remove obsolete YAML schema

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -20,22 +20,6 @@ from .tahoma_api import TahomaApi
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO Deprecate EXCLUDE for the native method of disabling entities
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_EXCLUDE, default=[]): vol.All(
-                    cv.ensure_list, [cv.string]
-                ),
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 PLATFORMS = [
     "binary_sensor",
     "climate",


### PR DESCRIPTION
Fixes #113

Currently we don't use the old YAML schema for configuring the integration. Do you think we need this in the integration to ease the migration? 

I would favour for a breaking change where we drop YAML support, which also happens for most other integrations.