### PR TITLE
Only trigger update if the device is available

### DIFF
--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -124,6 +124,8 @@ class TahomaDevice(Entity):
 
     def should_wait(self):
         """Wait for actions to finish."""
+        if not self.available:
+            return True
         exec_queue = self.controller.get_current_executions()
         self._exec_queue = [e for e in self._exec_queue if e in exec_queue]
         return True if self._exec_queue else False


### PR DESCRIPTION
This prevents following messages in the log at startup:
`Unable to update from sensor: could not convert string to float: 'unavailable'`