### PR TITLE
Remove .format().

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -164,26 +164,19 @@ class TahomaSensor(TahomaDevice, Entity):
             self.current_value = states.get(CORE_LUMINANCE_STATE)
 
         if CORE_RELATIVE_HUMIDITY_STATE in states:
-            self.current_value = float(
-                "{:.2f}".format(states.get(CORE_RELATIVE_HUMIDITY_STATE))
-            )
+            self.current_value = float(states.get(CORE_RELATIVE_HUMIDITY_STATE))
 
         if CORE_TEMPERATURE_STATE in states:
-            self.current_value = float(
-                "{:.2f}".format(states.get(CORE_TEMPERATURE_STATE))
-            )
+            self.current_value = float(states.get(CORE_TEMPERATURE_STATE))
 
         if CORE_ELECTRIC_POWER_CONSUMPTION_STATE in states:
             self.current_value = float(
-                "{:.2f}".format(states.get(CORE_ELECTRIC_POWER_CONSUMPTION_STATE))
+                states.get(CORE_ELECTRIC_POWER_CONSUMPTION_STATE)
             )
 
         if CORE_ELECTRIC_ENERGY_CONSUMPTION_STATE in states:
             self.current_value = (
-                float(
-                    "{:.2f}".format(states.get(CORE_ELECTRIC_ENERGY_CONSUMPTION_STATE))
-                )
-                / 1000
+                float(states.get(CORE_ELECTRIC_ENERGY_CONSUMPTION_STATE)) / 1000
             )
 
         if CORE_CO_CONCENTRATION_STATE in states:


### PR DESCRIPTION
States are already formatted as numbers in TahomaApi
`def set_active_state(self, name, value):` (line 652)

https://github.com/iMicknl/ha-tahoma/blob/a518ba3f9909a6713b0b1a2c0bb9be7a9bc5ac59/custom_components/tahoma/tahoma_api.py#L652

Github issue #110