### PR TITLE
Group entities that belong to the same device

### DIFF
--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -119,7 +119,7 @@ class TahomaDevice(Entity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
+            "identifiers": {(DOMAIN, self.unique_id.split("#", 1)[0])},
             "manufacturer": "Somfy",
             "name": self.name,
             "model": self.tahoma_device.widget,


### PR DESCRIPTION
Some of my device urls look like: "io://xxxxx/4468654#10", "io://xxxxx/4468654#9"... 
We can use this to group several entities in the same device.