### PR TITLE
Improve entity update after command execution, add retry logic

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -106,7 +106,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         name="TaHoma Event Fetcher",
         client=client,
         devices=await client.get_devices(),
-        listener_id=await client.register_event_listener(),
         update_interval=timedelta(seconds=update_interval),
     )
 

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import timedelta
 import logging
 
+from aiohttp import CookieJar
 from pyhoma.client import TahomaClient
 from pyhoma.exceptions import BadCredentialsException, TooManyRequestsException
 import voluptuous as vol
@@ -18,7 +19,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 from .config_flow import CONF_UPDATE_INTERVAL
 from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, IGNORED_TAHOMA_TYPES, TAHOMA_TYPES
@@ -76,7 +77,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
 
-    client = TahomaClient(username, password)
+    session = aiohttp_client.async_create_clientsession(
+        hass, cookie_jar=CookieJar(unsafe=True)
+    )
+
+    client = TahomaClient(username, password, session=session)
 
     try:
         await client.login()

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -87,15 +87,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await client.login()
     except TooManyRequestsException:
         _LOGGER.error("too_many_requests")
-        await client.close()
         return False
     except BadCredentialsException:
         _LOGGER.error("invalid_auth")
-        await client.close()
         return False
     except Exception as exception:  # pylint: disable=broad-except
         _LOGGER.exception(exception)
-        await client.close()
         return False
 
     update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
@@ -140,19 +137,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    async def async_close_client(self, *_):
-        """Close HTTP client."""
-        await client.close()
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_close_client)
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
 
-    await hass.data[DOMAIN][entry.entry_id].get("coordinator").client.close()
     await hass.data[DOMAIN][entry.entry_id].get("update_listener")()
 
     entities_per_platform = hass.data[DOMAIN][entry.entry_id]["entities"]

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -143,8 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
 
-    await hass.data[DOMAIN][entry.entry_id].get("update_listener")()
-
+    hass.data[DOMAIN][entry.entry_id]["update_listener"]()
     entities_per_platform = hass.data[DOMAIN][entry.entry_id]["entities"]
 
     unload_ok = all(

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         configuration.get(CONF_USERNAME) in entry.data.get(CONF_USERNAME)
         for entry in hass.config_entries.async_entries(DOMAIN)
     ):
-        return True
+        return False
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -16,8 +16,13 @@ from homeassistant.const import CONF_EXCLUDE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .config_flow import CONF_UPDATE_INTERVAL
-from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, IGNORED_TAHOMA_TYPES, TAHOMA_TYPES
+from .const import (
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    IGNORED_TAHOMA_TYPES,
+    TAHOMA_TYPES,
+)
 from .coordinator import TahomaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.scene import DOMAIN as SCENE
-from homeassistant.components.tahoma.config_flow import CONF_UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_EXCLUDE,
@@ -21,6 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
+from .config_flow import CONF_UPDATE_INTERVAL
 from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, IGNORED_TAHOMA_TYPES, TAHOMA_TYPES
 from .coordinator import TahomaDataUpdateCoordinator
 

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -180,3 +180,5 @@ async def update_listener(hass, entry):
         coordinator.update_interval = (
             coordinator.original_update_interval
         ) = new_update_interval
+
+        await coordinator.async_refresh()

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -1,6 +1,7 @@
 """The TaHoma integration."""
 import asyncio
 from collections import defaultdict
+from datetime import timedelta
 import logging
 
 from pyhoma.client import TahomaClient
@@ -9,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.scene import DOMAIN as SCENE
+from homeassistant.components.tahoma.config_flow import CONF_UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_EXCLUDE,
@@ -91,6 +93,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await client.close()
         return False
 
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+
     tahoma_coordinator = TahomaDataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -99,7 +103,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         client=client,
         devices=await client.get_devices(),
         listener_id=await client.register_event_listener(),
-        update_interval=DEFAULT_UPDATE_INTERVAL,
+        update_interval=timedelta(seconds=update_interval),
     )
 
     await tahoma_coordinator.async_refresh()

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -98,7 +98,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     tahoma_coordinator = TahomaDataUpdateCoordinator(
         hass,
         _LOGGER,
-        # Name of the data. For logging purposes.
         name="TaHoma Event Fetcher",
         client=client,
         devices=await client.get_devices(),

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         configuration.get(CONF_USERNAME) in entry.data.get(CONF_USERNAME)
         for entry in hass.config_entries.async_entries(DOMAIN)
     ):
-        return False
+        return True
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -12,12 +12,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.scene import DOMAIN as SCENE
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_EXCLUDE,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import CONF_EXCLUDE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -166,8 +166,7 @@ async def update_listener(hass, entry):
     if entry.options[CONF_UPDATE_INTERVAL]:
         coordinator = hass.data[DOMAIN][entry.entry_id].get("coordinator")
         new_update_interval = timedelta(seconds=entry.options[CONF_UPDATE_INTERVAL])
-        coordinator.update_interval = (
-            coordinator.original_update_interval
-        ) = new_update_interval
+        coordinator.update_interval = new_update_interval
+        coordinator.original_update_interval = new_update_interval
 
         await coordinator.async_refresh()

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -119,7 +119,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_UPDATE_INTERVAL,
-                        default=self.config_entry.options.get(CONF_UPDATE_INTERVAL),
+                        default=self.options.get(CONF_UPDATE_INTERVAL),
                     ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
                 }
             ),

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -12,10 +12,14 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
-from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, MIN_UPDATE_INTERVAL
+from .const import (
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    MIN_UPDATE_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
-CONF_UPDATE_INTERVAL = "update_interval"
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -29,7 +29,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        """Handle the  flow."""
+        """Handle the flow."""
         return OptionsFlowHandler(config_entry)
 
     async def async_validate_input(self, user_input):

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -1,18 +1,19 @@
 """Config flow for TaHoma integration."""
-from asyncio import TimeoutError
 import logging
 
-from aiohttp import ClientError
 from pyhoma.client import TahomaClient
 from pyhoma.exceptions import BadCredentialsException, TooManyRequestsException
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, MIN_UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
+CONF_UPDATE_INTERVAL = "update_interval"
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
@@ -24,6 +25,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Handle the  flow."""
+        return OptionsFlowHandler(config_entry)
 
     async def async_validate_input(self, user_input):
         """Validate user credentials."""
@@ -48,8 +55,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "too_many_requests"
             except BadCredentialsException:
                 errors["base"] = "invalid_auth"
-            except (TimeoutError, ClientError):
-                errors["base"] = "cannot_connect"
             except Exception as exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
                 _LOGGER.exception(exception)
@@ -60,20 +65,49 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config: dict):
         """Handle the initial step via YAML configuration."""
-        if not import_config:
-            return
+        if import_config:
+            try:
+                return await self.async_validate_input(import_config)
+            except TooManyRequestsException:
+                _LOGGER.error("too_many_requests")
+                return self.async_abort(reason="too_many_requests")
+            except BadCredentialsException:
+                _LOGGER.error("invalid_auth")
+                return self.async_abort(reason="invalid_auth")
+            except Exception as exception:  # pylint: disable=broad-except
+                _LOGGER.exception(exception)
+                return self.async_abort(reason="unknown")
 
-        try:
-            return await self.async_validate_input(import_config)
-        except TooManyRequestsException:
-            _LOGGER.error("too_many_requests")
-            return self.async_abort(reason="too_many_requests")
-        except BadCredentialsException:
-            _LOGGER.error("invalid_auth")
-            return self.async_abort(reason="invalid_auth")
-        except (TimeoutError, ClientError):
-            _LOGGER.error("cannot_connect")
-            return self.async_abort(reason="cannot_connect")
-        except Exception as exception:  # pylint: disable=broad-except
-            _LOGGER.exception(exception)
-            return self.async_abort(reason="unknown")
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for TaHoma."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+        if self.options.get(CONF_UPDATE_INTERVAL) is None:
+            self.options[CONF_UPDATE_INTERVAL] = DEFAULT_UPDATE_INTERVAL
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Somfy TaHoma options."""
+        return await self.async_step_update_interval()
+
+    async def async_step_update_interval(self, user_input=None):
+        """Manage the options regarding interval updates."""
+        if user_input is not None:
+            self.options[CONF_UPDATE_INTERVAL] = user_input[CONF_UPDATE_INTERVAL]
+            return self.async_create_entry(title="", data=self.options)
+
+        return self.async_show_form(
+            step_id="update_interval",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_UPDATE_INTERVAL,
+                        default=self.config_entry.options.get(CONF_UPDATE_INTERVAL),
+                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
+                }
+            ),
+        )

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow for TaHoma integration."""
+from asyncio import TimeoutError
 import logging
 
+from aiohttp import ClientError
 from pyhoma.client import TahomaClient
 from pyhoma.exceptions import BadCredentialsException, TooManyRequestsException
 import voluptuous as vol
@@ -55,6 +57,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "too_many_requests"
             except BadCredentialsException:
                 errors["base"] = "invalid_auth"
+            except (TimeoutError, ClientError):
+                errors["base"] = "cannot_connect"
             except Exception as exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
                 _LOGGER.exception(exception)
@@ -65,18 +69,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config: dict):
         """Handle the initial step via YAML configuration."""
-        if import_config:
-            try:
-                return await self.async_validate_input(import_config)
-            except TooManyRequestsException:
-                _LOGGER.error("too_many_requests")
-                return self.async_abort(reason="too_many_requests")
-            except BadCredentialsException:
-                _LOGGER.error("invalid_auth")
-                return self.async_abort(reason="invalid_auth")
-            except Exception as exception:  # pylint: disable=broad-except
-                _LOGGER.exception(exception)
-                return self.async_abort(reason="unknown")
+        if not import_config:
+            return
+
+        try:
+            return await self.async_validate_input(import_config)
+        except TooManyRequestsException:
+            _LOGGER.error("too_many_requests")
+            return self.async_abort(reason="too_many_requests")
+        except BadCredentialsException:
+            _LOGGER.error("invalid_auth")
+            return self.async_abort(reason="invalid_auth")
+        except (TimeoutError, ClientError):
+            _LOGGER.error("cannot_connect")
+            return self.async_abort(reason="cannot_connect")
+        except Exception as exception:  # pylint: disable=broad-except
+            _LOGGER.exception(exception)
+            return self.async_abort(reason="unknown")
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -1,5 +1,7 @@
 """Constants for the TaHoma integration."""
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_CONTROL_PANEL
+from datetime import timedelta
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.climate import DOMAIN as CLIMATE
 from homeassistant.components.cover import DOMAIN as COVER
@@ -9,6 +11,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
 
 DOMAIN = "tahoma"
+DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
 
 IGNORED_TAHOMA_TYPES = [
     "ProtocolGateway",

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -1,7 +1,5 @@
 """Constants for the TaHoma integration."""
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_CONTROL_PANEL
-from datetime import timedelta
-
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.climate import DOMAIN as CLIMATE
 from homeassistant.components.cover import DOMAIN as COVER

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -11,7 +11,9 @@ from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
 
 DOMAIN = "tahoma"
-DEFAULT_UPDATE_INTERVAL = timedelta(seconds=30)
+
+MIN_UPDATE_INTERVAL = 1
+DEFAULT_UPDATE_INTERVAL = 30
 
 IGNORED_TAHOMA_TYPES = [
     "ProtocolGateway",

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -75,3 +75,5 @@ CORE_ON_OFF_STATE = "core:OnOffState"
 
 COMMAND_OFF = "off"
 COMMAND_ON = "on"
+
+CONF_UPDATE_INTERVAL = "update_interval"

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -54,10 +54,8 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with the TaHoma API: {exception}")
         else:
             for event in events:
-                print(f"{event.name} {event.exec_id} {event.deviceurl}")
-
                 if event.name == "DeviceAvailableEvent":
-                    print(event.deviceurl)
+                    self.devices[event.deviceurl].available = True
 
                 if event.name == "DeviceStateChangedEvent":
                     for state in event.device_states:
@@ -66,7 +64,10 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
                             device.states[state.name] = state
                         device.states[state.name].value = self._get_state(state)
 
-                if event.name == "ExecutionRegisteredEvent":
+                if (
+                    event.name == "ExecutionRegisteredEvent"
+                    and event.exec_id in self.executions
+                ):
                     self.update_interval = timedelta(seconds=1)
 
                 if (

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -78,7 +78,7 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.executions.pop(event.exec_id, None)
 
             if len(self.executions) < 1:
-                self.update_interval = timedelta(seconds=self.original_update_interval)
+                self.update_interval = self.original_update_interval
 
             return self.devices
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -74,7 +74,10 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
             if event.name == "DeviceAvailableEvent":
                 self.devices[event.deviceurl].available = True
 
-            if event.name == "DeviceStateChangedEvent":
+            elif event.name == "DeviceUnavailableEvent":
+                self.devices[event.deviceurl].available = False
+
+            elif event.name == "DeviceStateChangedEvent":
                 for state in event.device_states:
                     device = self.devices[event.deviceurl]
                     if state.name not in device.states:

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -41,6 +41,7 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
             hass, logger, name=name, update_interval=update_interval,
         )
 
+        self.original_update_interval = update_interval
         self.client = client
         self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
         self.executions: Dict[str, defaultdict] = {}
@@ -77,7 +78,7 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.executions.pop(event.exec_id, None)
 
             if len(self.executions) < 1:
-                self.update_interval = DEFAULT_UPDATE_INTERVAL
+                self.update_interval = timedelta(seconds=self.original_update_interval)
 
             return self.devices
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -54,7 +54,6 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
         except (ServerDisconnectedError, NotAuthenticatedException) as exception:
             _LOGGER.debug(exception)
             await self.client.login()
-            await self.client.register_event_listener()
             self.devices = {
                 d.deviceurl: d for d in await self.client.get_devices(refresh=True)
             }

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -79,17 +79,16 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
                         device.states[state.name] = state
                     device.states[state.name].value = self._get_state(state)
 
-            if (
-                event.name == "ExecutionRegisteredEvent"
-                and event.exec_id in self.executions
-            ):
+            if event.name == "ExecutionRegisteredEvent":
+                if event.exec_id not in self.executions:
+                    self.coordinator.executions[event.exec_id] = {}
+
                 self.update_interval = timedelta(seconds=1)
 
             if (
                 event.name == "ExecutionStateChangedEvent"
                 and event.exec_id in self.executions
-                and event.new_state == "COMPLETED"
-                or event.new_state == "FAILED"
+                and event.new_state in ["COMPLETED", "FAILED"]
             ):
                 del self.executions[event.exec_id]
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -78,16 +78,14 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.update_interval = timedelta(seconds=1)
 
                 if (
-                    (
-                        event.name == "ExecutionStateChangedEvent"
-                        and event.exec_id in self.executions
-                    )
+                    event.name == "ExecutionStateChangedEvent"
+                    and event.exec_id in self.executions
                     and event.new_state == "COMPLETED"
                     or event.new_state == "FAILED"
                 ):
                     del self.executions[event.exec_id]
 
-            if len(self.executions) < 1:
+            if not self.executions:
                 self.update_interval = self.original_update_interval
 
             return self.devices

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -81,7 +81,7 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
 
             if event.name == "ExecutionRegisteredEvent":
                 if event.exec_id not in self.executions:
-                    self.coordinator.executions[event.exec_id] = {}
+                    self.executions[event.exec_id] = {}
 
                 self.update_interval = timedelta(seconds=1)
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -4,7 +4,9 @@ from datetime import timedelta
 import logging
 from typing import Dict, List, Optional, Union
 
+from aiohttp import ServerDisconnectedError
 from pyhoma.client import TahomaClient
+from pyhoma.exceptions import NotAuthenticatedException
 from pyhoma.models import DataType, Device, State
 
 from homeassistant.core import HomeAssistant
@@ -50,45 +52,53 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
         self.listener_id = listener_id
 
     async def _async_update_data(self) -> Dict[str, Device]:
-        """Fetch data from Tahoma."""
+        """Fetch TaHoma data via event listener."""
         try:
             events = await self.client.fetch_event_listener(self.listener_id)
-        except Exception as exception:
-            raise UpdateFailed(f"Error communicating with the TaHoma API: {exception}")
-        else:
-            for event in events:
-                _LOGGER.debug(
-                    f"{event.name}/{event.exec_id} (device:{event.deviceurl},state:{event.old_state}->{event.new_state})"
-                )
-
-                if event.name == "DeviceAvailableEvent":
-                    self.devices[event.deviceurl].available = True
-
-                if event.name == "DeviceStateChangedEvent":
-                    for state in event.device_states:
-                        device = self.devices[event.deviceurl]
-                        if state.name not in device.states:
-                            device.states[state.name] = state
-                        device.states[state.name].value = self._get_state(state)
-
-                if (
-                    event.name == "ExecutionRegisteredEvent"
-                    and event.exec_id in self.executions
-                ):
-                    self.update_interval = timedelta(seconds=1)
-
-                if (
-                    event.name == "ExecutionStateChangedEvent"
-                    and event.exec_id in self.executions
-                    and event.new_state == "COMPLETED"
-                    or event.new_state == "FAILED"
-                ):
-                    del self.executions[event.exec_id]
-
-            if not self.executions:
-                self.update_interval = self.original_update_interval
-
+        except (ServerDisconnectedError, NotAuthenticatedException) as exception:
+            _LOGGER.debug(exception)
+            await self.client.login()
+            self.listener_id = await self.client.register_event_listener()
+            self.devices = {
+                d.deviceurl: d for d in await self.client.get_devices(refresh=True)
+            }
             return self.devices
+        except Exception as exception:
+            raise UpdateFailed(exception)
+
+        for event in events:
+            _LOGGER.debug(
+                f"{event.name}/{event.exec_id} (device:{event.deviceurl},state:{event.old_state}->{event.new_state})"
+            )
+
+            if event.name == "DeviceAvailableEvent":
+                self.devices[event.deviceurl].available = True
+
+            if event.name == "DeviceStateChangedEvent":
+                for state in event.device_states:
+                    device = self.devices[event.deviceurl]
+                    if state.name not in device.states:
+                        device.states[state.name] = state
+                    device.states[state.name].value = self._get_state(state)
+
+            if (
+                event.name == "ExecutionRegisteredEvent"
+                and event.exec_id in self.executions
+            ):
+                self.update_interval = timedelta(seconds=1)
+
+            if (
+                event.name == "ExecutionStateChangedEvent"
+                and event.exec_id in self.executions
+                and event.new_state == "COMPLETED"
+                or event.new_state == "FAILED"
+            ):
+                del self.executions[event.exec_id]
+
+        if not self.executions:
+            self.update_interval = self.original_update_interval
+
+        return self.devices
 
     @staticmethod
     def _get_state(state: State) -> Union[float, int, bool, str, None]:

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -1,5 +1,4 @@
 """Helpers to help coordinate updates."""
-from collections import defaultdict
 from datetime import timedelta
 import logging
 from typing import Dict, List, Optional, Union

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -52,6 +52,7 @@ class TahomaDataUpdateCoordinator(DataUpdateCoordinator):
             events = await self.client.fetch_events()
         except (ServerDisconnectedError, NotAuthenticatedException) as exception:
             _LOGGER.debug(exception)
+            self.executions = {}
             await self.client.login()
             self.devices = {
                 d.deviceurl: d for d in await self.client.get_devices(refresh=True)

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -250,7 +250,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
                     execution
                     for execution in self.coordinator.executions.values()
                     if execution.get("deviceurl") == self.device.deviceurl
-                    and execution.get("command") in list(COMMAND_OPEN, COMMAND_UP)
+                    and execution.get("command_name") in list(COMMAND_OPEN, COMMAND_UP)
                 ),
                 None,
             )
@@ -266,7 +266,8 @@ class TahomaCover(TahomaDevice, CoverEntity):
                     execution
                     for execution in self.coordinator.executions.values()
                     if execution.get("deviceurl") == self.device.deviceurl
-                    and execution.get("command") in list(COMMAND_CLOSE, COMMAND_DOWN)
+                    and execution.get("command_name")
+                    in list(COMMAND_CLOSE, COMMAND_DOWN)
                 ),
                 None,
             )

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -244,29 +244,21 @@ class TahomaCover(TahomaDevice, CoverEntity):
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return next(
-            (
-                True
-                for execution in self.coordinator.executions.values()
-                if execution["deviceurl"] == self.device.deviceurl
-                and execution["command_name"]
-                in [COMMAND_OPEN, COMMAND_UP, COMMAND_OPEN_SLATS]
-            ),
-            False,
+        return any(
+            execution["deviceurl"] == self.device.deviceurl
+            and execution["command_name"]
+            in [COMMAND_OPEN, COMMAND_UP, COMMAND_OPEN_SLATS]
+            for execution in self.coordinator.executions.values()
         )
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return next(
-            (
-                True
-                for execution in self.coordinator.executions.values()
-                if execution["deviceurl"] == self.device.deviceurl
-                and execution["command_name"]
-                in [COMMAND_CLOSE, COMMAND_DOWN, COMMAND_CLOSE_SLATS]
-            ),
-            False,
+        return any(
+            execution["deviceurl"] == self.device.deviceurl
+            and execution["command_name"]
+            in [COMMAND_CLOSE, COMMAND_DOWN, COMMAND_CLOSE_SLATS]
+            for execution in self.coordinator.executions.values()
         )
 
     @property

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -248,8 +248,9 @@ class TahomaCover(TahomaDevice, CoverEntity):
             (
                 True
                 for execution in self.coordinator.executions.values()
-                if execution.get("deviceurl") == self.device.deviceurl
-                and execution.get("command_name") in list(COMMAND_OPEN, COMMAND_UP)
+                if execution["deviceurl"] == self.device.deviceurl
+                and execution["command_name"]
+                in [COMMAND_OPEN, COMMAND_UP, COMMAND_OPEN_SLATS]
             ),
             False,
         )
@@ -261,8 +262,9 @@ class TahomaCover(TahomaDevice, CoverEntity):
             (
                 True
                 for execution in self.coordinator.executions.values()
-                if execution.get("deviceurl") == self.device.deviceurl
-                and execution.get("command_name") in list(COMMAND_CLOSE, COMMAND_DOWN)
+                if execution["deviceurl"] == self.device.deviceurl
+                and execution["command_name"]
+                in [COMMAND_CLOSE, COMMAND_DOWN, COMMAND_CLOSE_SLATS]
             ),
             False,
         )

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -242,6 +242,38 @@ class TahomaCover(TahomaDevice, CoverEntity):
         await self.async_execute_command(COMMAND_MY)
 
     @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return (
+            next(
+                (
+                    execution
+                    for execution in self.coordinator.executions.values()
+                    if execution.get("deviceurl") == self.device.deviceurl
+                    and execution.get("command") in list(COMMAND_OPEN, COMMAND_UP)
+                ),
+                None,
+            )
+            is not None
+        )
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return (
+            next(
+                (
+                    execution
+                    for execution in self.coordinator.executions.values()
+                    if execution.get("deviceurl") == self.device.deviceurl
+                    and execution.get("command") in list(COMMAND_CLOSE, COMMAND_DOWN)
+                ),
+                None,
+            )
+            is not None
+        )
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         supported_features = 0

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -245,8 +245,8 @@ class TahomaCover(TahomaDevice, CoverEntity):
     def is_opening(self):
         """Return if the cover is opening or not."""
         return any(
-            execution["deviceurl"] == self.device.deviceurl
-            and execution["command_name"]
+            execution.get("deviceurl") == self.device.deviceurl
+            and execution.get("command_name")
             in [COMMAND_OPEN, COMMAND_UP, COMMAND_OPEN_SLATS]
             for execution in self.coordinator.executions.values()
         )
@@ -255,8 +255,8 @@ class TahomaCover(TahomaDevice, CoverEntity):
     def is_closing(self):
         """Return if the cover is closing or not."""
         return any(
-            execution["deviceurl"] == self.device.deviceurl
-            and execution["command_name"]
+            execution.get("deviceurl") == self.device.deviceurl
+            and execution.get("command_name")
             in [COMMAND_CLOSE, COMMAND_DOWN, COMMAND_CLOSE_SLATS]
             for execution in self.coordinator.executions.values()
         )

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -244,34 +244,27 @@ class TahomaCover(TahomaDevice, CoverEntity):
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return (
-            next(
-                (
-                    execution
-                    for execution in self.coordinator.executions.values()
-                    if execution.get("deviceurl") == self.device.deviceurl
-                    and execution.get("command_name") in list(COMMAND_OPEN, COMMAND_UP)
-                ),
-                None,
-            )
-            is not None
+        return next(
+            (
+                True
+                for execution in self.coordinator.executions.values()
+                if execution.get("deviceurl") == self.device.deviceurl
+                and execution.get("command_name") in list(COMMAND_OPEN, COMMAND_UP)
+            ),
+            False,
         )
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return (
-            next(
-                (
-                    execution
-                    for execution in self.coordinator.executions.values()
-                    if execution.get("deviceurl") == self.device.deviceurl
-                    and execution.get("command_name")
-                    in list(COMMAND_CLOSE, COMMAND_DOWN)
-                ),
-                None,
-            )
-            is not None
+        return next(
+            (
+                True
+                for execution in self.coordinator.executions.values()
+                if execution.get("deviceurl") == self.device.deviceurl
+                and execution.get("command_name") in list(COMMAND_CLOSE, COMMAND_DOWN)
+            ),
+            False,
         )
 
     @property

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.3.5"
+    "pyhoma==0.4.0"
   ],
   "codeowners": ["@philklei", "@imicknl", "@vlebourl", "@tetienne"],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues"

--- a/custom_components/tahoma/strings.json
+++ b/custom_components/tahoma/strings.json
@@ -20,20 +20,13 @@
   },
   "options": {
     "step": {
-      "init": {
-        "description": "Select temperature sensors for thermostats and preset temperatures.\nNote: reset temperatures do not apply to the Smart Thermostat.",
+      "update_interval": {
+        "title": "Update Interval",
+        "description": "The Somfy TaHoma integration periodically checks for new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
         "data": {
-          "_": "entity",
-          "no_climate": "No climate device, you can close this window",
-          "freeze": "Anti-Freeze preset temperature",
-          "eco": "Eco preset temperature",
-          "away": "Away preset temperature",
-          "comfort": "Comfort preset temperature"
+          "update_interval": "Update interval (in seconds)"
         }
       }
-    },
-    "error": {
-      "invalid_sensor": "Please select a valid sensor from the list"
     }
   }
 }

--- a/custom_components/tahoma/strings.json
+++ b/custom_components/tahoma/strings.json
@@ -11,6 +11,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "too_many_requests": "Too many requests, try again later.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
@@ -22,7 +23,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically checks for new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
+        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -152,6 +152,14 @@ class TahomaDevice(Entity):
 
     async def async_execute_command(self, command_name: str, *args: Any):
         """Execute device command in async context."""
-        await self.coordinator.client.execute_command(
+        exec_id = await self.coordinator.client.execute_command(
             self.device.deviceurl, Command(command_name, list(args)), "Home Assistant"
         )
+
+        # ExecutionRegisteredEvent doesn't have a device url, thus we need to register it here already
+        self.coordinator.executions[exec_id] = {
+            "deviceurl": self.device.deviceurl,
+            "command": command_name,
+        }
+
+        await self.coordinator.async_refresh()

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -156,10 +156,10 @@ class TahomaDevice(Entity):
             self.device.deviceurl, Command(command_name, list(args)), "Home Assistant"
         )
 
-        # ExecutionRegisteredEvent doesn't have a device url, thus we need to register it here already
+        # ExecutionRegisteredEvent doesn't contain the deviceurl, thus we need to register it here
         self.coordinator.executions[exec_id] = {
             "deviceurl": self.device.deviceurl,
-            "command": command_name,
+            "command_name": command_name,
         }
 
         await self.coordinator.async_refresh()

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -21,20 +21,13 @@
   },
   "options": {
     "step": {
-      "init": {
-        "description": "Select temperature sensors for thermostats and preset temperatures.\nNote: reset temperatures do not apply to the Smart Thermostat.",
+      "update_interval": {
+        "title": "Update Interval",
+        "description": "The Somfy TaHoma integration periodically listens to new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
         "data": {
-          "_": "entity",
-          "no_climate": "No climate device, you can close this window",
-          "freeze": "Anti-Freeze preset temperature",
-          "eco": "Eco preset temperature",
-          "away": "Away preset temperature",
-          "comfort": "Comfort preset temperature"
+          "update_interval": "Update interval (in seconds)"
         }
       }
-    },
-    "error": {
-      "invalid_sensor": "Please select a valid sensor from the list"
     }
   }
 }

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -23,7 +23,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
+        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -23,7 +23,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
+        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -23,7 +23,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically listens to new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
+        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you use a physical remote to control your devices.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/translations/fr.json
+++ b/custom_components/tahoma/translations/fr.json
@@ -11,11 +11,23 @@
     },
     "error": {
       "cannot_connect": "Connexion impossible",
+      "too_many_requests": "Trop de reqûtees, veuillez réessayer plus tard.",
       "invalid_auth": "Mot de passe ou nom d'utilisateur incorrect",
       "unknown": "Une erreur inconnue est survenue."
     },
     "abort": {
       "already_configured": "Votre compte a déjà été ajouté pour cette intégration."
+    }
+  },
+  "options": {
+    "step": {
+      "update_interval": {
+        "title": "Intervalle de mise à jour",
+        "description": "L'intégration Somfy TaHoma récupère régulièrement de nouveaux évènements. Modifiez l'intervalle de mise à jour par une valeur inférieure si vous souhaitez des mises à jour plus fréquentes, par exemple quand vous contrôllez aussi vos appareils en dehors de Home Assistant.",
+        "data": {
+          "update_interval": "Intervalle de mise à jour (en secondes)"
+        }
+      }
     }
   }
 }

--- a/custom_components/tahoma/translations/nl.json
+++ b/custom_components/tahoma/translations/nl.json
@@ -18,5 +18,16 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "options": {
+    "step": {
+      "update_interval": {
+        "title": "Update interval",
+        "description": "De Somfy TaHoma-integratie haalt periodiek nieuwe gebeurtenissen op. Verander het update-interval naar een lagere waarde als u een fysieke afstandsbediening gebruikt om uw apparaten te bedienen.",
+        "data": {
+          "update_interval": "Update interval (in seconden)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/tahoma/translations/nl.json
+++ b/custom_components/tahoma/translations/nl.json
@@ -23,7 +23,7 @@
     "step": {
       "update_interval": {
         "title": "Update interval",
-        "description": "De Somfy TaHoma-integratie haalt periodiek nieuwe gebeurtenissen op. Verander het update-interval naar een lagere waarde als u een fysieke afstandsbediening gebruikt om uw apparaten te bedienen.",
+        "description": "De Somfy TaHoma-integratie haalt periodiek nieuwe gebeurtenissen op. Wijzig de update-interval naar een lagere waarde als je vaker updates wilt, bijvoorbeeld wanneer je je apparaten ook buiten Home Assistant bedient.",
         "data": {
           "update_interval": "Update interval (in seconden)"
         }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,4 +7,4 @@ pytest-cov<3.0.0
 pytest-homeassistant
 
 # from our manifest.json for our Custom Component
-pyhoma==0.3.5
+pyhoma==0.4.0


### PR DESCRIPTION
Currently, the default execution is set to 10 seconds, which is terribly slow when turning on/off a light. It would be good to poll every second after a command is executed, until the execution is finished.

This will allow us to poll the event listener every minute or hour for installations where the remote is not / rarely used. By making it configurable via an Option Flow, users adjust it to their scenario.

## What's changed

## ✨ Enhancement
* Make scan interval configurable
* Visually show if covers are opening or closing
* Improve entity update speed after command execution via HA

## 🐛 Bug Fixes
* Close client on error

<img width="405" alt="Screenshot 2020-08-15 at 21 20 55" src="https://user-images.githubusercontent.com/1424596/90319980-52995100-df3d-11ea-9e7d-ff7b0b110155.png">
<img width="608" alt="Screenshot 2020-08-20 at 14 33 24" src="https://user-images.githubusercontent.com/1424596/90770478-217ca000-e2f2-11ea-84bf-a08e9cf581f2.png">
