### PR TITLE
Add `my` service for light and cover devices

### DIFF
--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -22,6 +22,7 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverEntity,
 )
+from homeassistant.helpers import entity_platform
 
 from .const import DOMAIN
 from .tahoma_device import TahomaDevice
@@ -65,6 +66,8 @@ IO_PRIORITY_LOCK_ORIGINATOR_STATE = "io:PriorityLockOriginatorState"
 
 STATE_CLOSED = "closed"
 
+SERVICE_MY = "cover_my"
+
 TAHOMA_COVER_DEVICE_CLASSES = {
     "Awning": DEVICE_CLASS_AWNING,
     "Blind": DEVICE_CLASS_BLIND,
@@ -94,6 +97,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     ]
 
     async_add_entities(entities)
+
+    platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_MY, {}, "async_my",
+    )
 
 
 class TahomaCover(TahomaDevice, CoverEntity):
@@ -228,6 +236,10 @@ class TahomaCover(TahomaDevice, CoverEntity):
         await self.async_execute_command(
             self.select_command(COMMAND_STOP_IDENTIFY, COMMAND_STOP, COMMAND_MY)
         )
+
+    async def async_my(self, **_):
+        """Set cover to preset position."""
+        await self.async_execute_command(COMMAND_MY)
 
     @property
     def supported_features(self):

--- a/custom_components/tahoma/light.py
+++ b/custom_components/tahoma/light.py
@@ -1,5 +1,4 @@
 """TaHoma light platform that implements dimmable TaHoma lights."""
-from datetime import timedelta
 import logging
 
 from homeassistant.components.light import (
@@ -13,6 +12,7 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.const import STATE_ON
+from homeassistant.helpers import entity_platform
 import homeassistant.util.color as color_util
 
 from .const import COMMAND_OFF, COMMAND_ON, CORE_ON_OFF_STATE, DOMAIN
@@ -20,14 +20,17 @@ from .tahoma_device import TahomaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
+COMMAND_MY = "my"
 COMMAND_SET_INTENSITY = "setIntensity"
-COMMAND_WINK = "wink"
 COMMAND_SET_RGB = "setRGB"
+COMMAND_WINK = "wink"
 
 CORE_BLUE_COLOR_INTENSITY_STATE = "core:BlueColorIntensityState"
 CORE_GREEN_COLOR_INTENSITY_STATE = "core:GreenColorIntensityState"
 CORE_LIGHT_INTENSITY_STATE = "core:LightIntensityState"
 CORE_RED_COLOR_INTENSITY_STATE = "core:RedColorIntensityState"
+
+SERVICE_MY = "light_my"
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -42,6 +45,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     ]
 
     async_add_entities(entities)
+
+    platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_MY, {}, "async_my",
+    )
 
 
 class TahomaLight(TahomaDevice, LightEntity):
@@ -109,11 +117,13 @@ class TahomaLight(TahomaDevice, LightEntity):
         else:
             await self.async_execute_command(COMMAND_ON)
 
-        self.async_write_ha_state()
-
     async def async_turn_off(self, **_) -> None:
         """Turn the light off."""
         await self.async_execute_command(COMMAND_OFF)
+
+    async def async_my(self, **_):
+        """Set light to preset position."""
+        await self.async_execute_command(COMMAND_MY)
 
     @property
     def effect_list(self) -> list:

--- a/custom_components/tahoma/services.yaml
+++ b/custom_components/tahoma/services.yaml
@@ -1,0 +1,13 @@
+cover_my:
+  description: Move cover to preset position, simulating the "my" button.
+  fields:
+    entity_id:
+      description: Name of entity that will be set to preset position.
+      example: "cover.living_room"
+
+light_my:
+  description: Move light to preset position, simulating the "my" button.
+  fields:
+    entity_id:
+      description: Name of entity that will be set to preset position.
+      example: "light.living_room"


### PR DESCRIPTION
Closes #220 

For now, I did register `tahoma.cover_my` and `tahoma.light_my` since I was not able to link `tahoma.my` to multiple entities... 

I tried creating tahoma.cover.my and tahoma.light.my as well, however in this case the services.yaml doesn't get read correctly.
