### PR TITLE
Add service to refresh states on TaHoma box

### DIFF
--- a/custom_components/tahoma/alarm_control_panel.py
+++ b/custom_components/tahoma/alarm_control_panel.py
@@ -80,11 +80,11 @@ MAP_VERISURE_STATUS_STATE = {
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaAlarmControlPanel(device.deviceurl, coordinator)
-        for device in data.get("entities").get(ALARM_CONTROL_PANEL)
+        for device in data["entities"].get(ALARM_CONTROL_PANEL)
     ]
     async_add_entities(entities)
 

--- a/custom_components/tahoma/binary_sensor.py
+++ b/custom_components/tahoma/binary_sensor.py
@@ -62,11 +62,11 @@ TAHOMA_BINARY_SENSOR_DEVICE_CLASSES = {
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaBinarySensor(device.deviceurl, coordinator)
-        for device in data.get("entities").get(BINARY_SENSOR)
+        for device in data["entities"].get(BINARY_SENSOR)
     ]
     async_add_entities(entities)
 

--- a/custom_components/tahoma/climate.py
+++ b/custom_components/tahoma/climate.py
@@ -5,22 +5,26 @@ from homeassistant.components.climate import DOMAIN as CLIMATE
 from .climate_devices.atlantic_electrical_heater import AtlanticElectricalHeater
 from .climate_devices.dimmer_exterior_heating import DimmerExteriorHeating
 from .climate_devices.somfy_thermostat import SomfyThermostat
+from .climate_devices.stateless_exterior_heating import StatelessExteriorHeating
 from .const import DOMAIN
 
 TYPE = {
     "AtlanticElectricalHeater": AtlanticElectricalHeater,
     "SomfyThermostat": SomfyThermostat,
     "DimmerExteriorHeating": DimmerExteriorHeating,
+    "StatelessExteriorHeating": StatelessExteriorHeating,
 }
+
+SERVICE_CLIMATE_MY_POSITION = "set_climate_my_position"
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma climate from a config entry."""
 
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
-    climate_devices = [device for device in data.get("entities").get(CLIMATE)]
+    climate_devices = [device for device in data["entities"].get(CLIMATE)]
 
     entities = [
         TYPE[device.widget](device.deviceurl, coordinator)

--- a/custom_components/tahoma/climate_devices/stateless_exterior_heating.py
+++ b/custom_components/tahoma/climate_devices/stateless_exterior_heating.py
@@ -1,0 +1,71 @@
+"""Support for Stateless Exterior Heating device."""
+import logging
+from typing import List, Optional
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_PRESET_MODE,
+)
+from homeassistant.const import TEMP_CELSIUS
+
+from ..tahoma_device import TahomaDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMAND_MY = "my"
+COMMAND_OFF = "off"
+COMMAND_ON = "on"
+
+PRESET_MY = "My"
+
+
+class StatelessExteriorHeating(TahomaDevice, ClimateEntity):
+    """Representation of TaHoma Stateless Exterior Heating device."""
+
+    @property
+    def temperature_unit(self) -> Optional[str]:
+        """Return the unit of measurement used by the platform."""
+        return TEMP_CELSIUS  # Not used but climate devices need a recognized temperature unit...
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return SUPPORT_PRESET_MODE
+
+    @property
+    def preset_mode(self) -> Optional[str]:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return None
+
+    @property
+    def preset_modes(self) -> Optional[List[str]]:
+        """Return a list of available preset modes."""
+        return [PRESET_MY]
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode in PRESET_MY:
+            await self.async_execute_command(COMMAND_MY)
+        else:
+            _LOGGER.error(
+                "Invalid preset mode %s for device %s", preset_mode, self.name
+            )
+
+    @property
+    def hvac_mode(self) -> Optional[str]:
+        """Return hvac operation ie. heat, cool mode."""
+        return None
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        """Return the list of available hvac operation modes."""
+        return [HVAC_MODE_OFF, HVAC_MODE_HEAT]
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        if hvac_mode == HVAC_MODE_HEAT:
+            await self.async_execute_command(COMMAND_ON)
+        else:
+            await self.async_execute_command(COMMAND_OFF)

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -21,9 +21,9 @@ IGNORED_TAHOMA_TYPES = [
 # Used to map the Somfy widget and ui_class to the Home Assistant platform
 TAHOMA_TYPES = {
     "AdjustableSlatsRollerShutter": COVER,
-    "Alarm": ALARM_CONTROL_PANEL,
     "AirFlowSensor": BINARY_SENSOR,  # widgetName, uiClass is AirSensor (sensor)
     "AirSensor": SENSOR,
+    "Alarm": ALARM_CONTROL_PANEL,
     "AtlanticElectricalHeater": CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     "Awning": COVER,
     "CarButtonSensor": BINARY_SENSOR,
@@ -31,6 +31,7 @@ TAHOMA_TYPES = {
     "ContactSensor": BINARY_SENSOR,
     "Curtain": COVER,
     "DimmerExteriorHeating": CLIMATE,  # widgetName, uiClass is ExteriorHeatingSystem (not supported)
+    "DomesticHotWaterTank": SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     "DoorLock": LOCK,
     "ElectricitySensor": SENSOR,
     "ExteriorScreen": COVER,
@@ -56,6 +57,7 @@ TAHOMA_TYPES = {
     "SirenStatus": BINARY_SENSOR,  # widgetName, uiClass is Siren (switch)
     "SmokeSensor": BINARY_SENSOR,
     "SomfyThermostat": CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
+    "StatelessExteriorHeating": CLIMATE,  # widgetName, uiClass is ExteriorHeatingSystem.
     "SunIntensitySensor": SENSOR,
     "SunSensor": SENSOR,
     "SwimmingPool": SWITCH,

--- a/custom_components/tahoma/light.py
+++ b/custom_components/tahoma/light.py
@@ -39,11 +39,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma lights from a config entry."""
 
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaLight(device.deviceurl, coordinator)
-        for device in data.get("entities").get(LIGHT)
+        for device in data["entities"].get(LIGHT)
     ]
 
     async_add_entities(entities)

--- a/custom_components/tahoma/lock.py
+++ b/custom_components/tahoma/lock.py
@@ -20,11 +20,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma locks from a config entry."""
 
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaLock(device.deviceurl, coordinator)
-        for device in data.get("entities").get(LOCK)
+        for device in data["entities"].get(LOCK)
     ]
 
     async_add_entities(entities)

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.4.1"
+    "pyhoma==0.4.2"
   ],
   "codeowners": ["@philklei", "@imicknl", "@vlebourl", "@tetienne"],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues"

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.4.0"
+    "pyhoma==0.4.1"
   ],
   "codeowners": ["@philklei", "@imicknl", "@vlebourl", "@tetienne"],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues"

--- a/custom_components/tahoma/scene.py
+++ b/custom_components/tahoma/scene.py
@@ -15,11 +15,10 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma scenes from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
-        TahomaScene(scene, coordinator.client)
-        for scene in data.get("entities").get(SCENE)
+        TahomaScene(scene, coordinator.client) for scene in data["entities"].get(SCENE)
     ]
     async_add_entities(entities)
 

--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
     TEMP_KELVIN,
-    UNIT_PERCENTAGE,
     VOLT,
     VOLUME_CUBIC_METERS,
     VOLUME_LITERS,
@@ -27,6 +26,12 @@ from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 from .tahoma_device import TahomaDevice
+
+try:  # TODO: Remove for core PR. This ensures compatibility with <0.115
+    from homeassistant.const import PERCENTAGE
+except Exception:
+    from homeassistant.const import UNIT_PERCENTAGE as PERCENTAGE
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +90,7 @@ UNITS = {
     "core:ElectricalPowerInMW": f"M{POWER_WATT}",
     "core:FlowInMeterCubePerHour": VOLUME_CUBIC_METERS,
     "core:LinearSpeedInMeterPerSecond": SPEED_METERS_PER_SECOND,
-    "core:RelativeValueInPercentage": UNIT_PERCENTAGE,
+    "core:RelativeValueInPercentage": PERCENTAGE,
     "core:VolumeInCubicMeter": VOLUME_CUBIC_METERS,
     "core:VolumeInLiter": VOLUME_LITERS,
     "core:FossilEnergyInWh": ENERGY_WATT_HOUR,
@@ -98,11 +103,11 @@ UNITS = {
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaSensor(device.deviceurl, coordinator)
-        for device in data.get("entities").get(SENSOR)
+        for device in data["entities"].get(SENSOR)
         if device.states
     ]
 

--- a/custom_components/tahoma/services.yaml
+++ b/custom_components/tahoma/services.yaml
@@ -21,3 +21,6 @@ set_cover_position_low_speed:
     position:
       description: Position of the cover (0 to 100).
       example: 30
+
+refresh_states:
+  description: Ask the box to refresh all devices states for protocols supporting that operation.

--- a/custom_components/tahoma/services.yaml
+++ b/custom_components/tahoma/services.yaml
@@ -24,3 +24,16 @@ set_cover_position_low_speed:
 
 refresh_states:
   description: Ask the box to refresh all devices states for protocols supporting that operation.
+
+execute_command:
+  description: Send a command to tahomalink endpoint through the API.
+  fields:
+    entity_id:
+      description: Name of entity that will be set to preset position.
+      example: "light.living_room"
+    command:
+      description: Command to send
+      example: "setIntensity"
+    args:
+      description: List of arguments to pass to the command if necessary
+      example: 100

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.switch import (
     DOMAIN as SWITCH,
     SwitchEntity,
 )
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 
 from .const import COMMAND_OFF, COMMAND_ON, CORE_ON_OFF_STATE, DOMAIN
 from .tahoma_device import TahomaDevice
@@ -17,7 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 COMMAND_CYCLE = "cycle"
 COMMAND_MEMORIZED_VOLUME = "memorizedVolume"
 COMMAND_RING_WITH_SINGLE_SIMPLE_SEQUENCE = "ringWithSingleSimpleSequence"
+COMMAND_SET_FORCE_HEATING = "setForceHeating"
 COMMAND_STANDARD = "standard"
+
+IO_FORCE_HEATING_STATE = "io:ForceHeatingState"
 
 DEVICE_CLASS_SIREN = "siren"
 
@@ -28,11 +31,11 @@ ICON_BELL_OFF = "mdi:bell-off"
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the TaHoma sensors from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data.get("coordinator")
+    coordinator = data["coordinator"]
 
     entities = [
         TahomaSwitch(device.deviceurl, coordinator)
-        for device in data.get("entities").get(SWITCH)
+        for device in data["entities"].get(SWITCH)
     ]
 
     async_add_entities(entities)
@@ -65,6 +68,9 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
         if self.has_command(COMMAND_ON):
             await self.async_execute_command(COMMAND_ON)
 
+        elif self.has_command(COMMAND_SET_FORCE_HEATING):
+            await self.async_execute_command(COMMAND_SET_FORCE_HEATING, STATE_ON)
+
         elif self.has_command(COMMAND_RING_WITH_SINGLE_SIMPLE_SEQUENCE):
             await self.async_execute_command(
                 COMMAND_RING_WITH_SINGLE_SIMPLE_SEQUENCE,  # https://www.tahomalink.com/enduser-mobile-web/steer-html5-client/vendor/somfy/io/siren/const.js
@@ -85,6 +91,9 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
                 COMMAND_STANDARD,
             )
 
+        elif self.has_command(COMMAND_SET_FORCE_HEATING):
+            await self.async_execute_command(COMMAND_SET_FORCE_HEATING, STATE_OFF)
+
         elif self.has_command(COMMAND_OFF):
             await self.async_execute_command(COMMAND_OFF)
 
@@ -96,4 +105,4 @@ class TahomaSwitch(TahomaDevice, SwitchEntity):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return self.select_state(CORE_ON_OFF_STATE) == STATE_ON
+        return self.select_state(CORE_ON_OFF_STATE, IO_FORCE_HEATING_STATE) == STATE_ON

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -163,3 +163,7 @@ class TahomaDevice(Entity):
         }
 
         await self.coordinator.async_refresh()
+
+    async def async_cancel_command(self, exec_id: str):
+        """Cancel device command in async context."""
+        await self.coordinator.client.cancel_command(exec_id)

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,4 +7,4 @@ pytest-cov<3.0.0
 pytest-homeassistant
 
 # from our manifest.json for our Custom Component
-pyhoma==0.4.0
+pyhoma==0.4.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,4 +7,4 @@ pytest-cov<3.0.0
 pytest-homeassistant
 
 # from our manifest.json for our Custom Component
-pyhoma==0.4.1
+pyhoma==0.4.2


### PR DESCRIPTION
A first try to solve the issues around states for devices that need a refresh. In this PR a service is added to manually refresh the states. If this is the solution, we could add this as an option to the DataUpdateCoordinator.

Fixes #167, #233, #230

Please note that after the refresh is complete, the event needs to be fetched via the DataUpdateCoordinator.
```2020-08-30 12:08:58 DEBUG (MainThread) [custom_components.tahoma.coordinator] RefreshAllDevicesStatesCompletedEvent/None (device:None,state:None->None)```