### PR TITLE
Handle exceptions in execution of commands

### DIFF
--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.4.2"
+    "pyhoma==0.4.3"
   ],
   "codeowners": ["@philklei", "@imicknl", "@vlebourl", "@tetienne"],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues"

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -1,4 +1,4 @@
-"""Parent class for every TaHoma devices."""
+"""Parent class for every TaHoma device."""
 import logging
 from typing import Any, Dict, Optional
 

--- a/custom_components/tahoma/tahoma_device.py
+++ b/custom_components/tahoma/tahoma_device.py
@@ -1,4 +1,5 @@
 """Parent class for every TaHoma devices."""
+import logging
 from typing import Any, Dict, Optional
 
 from pyhoma.models import Command, Device
@@ -23,6 +24,8 @@ STATE_BATTERY_NORMAL = "normal"
 STATE_BATTERY_LOW = "low"
 STATE_BATTERY_VERY_LOW = "verylow"
 STATE_DEAD = "dead"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TahomaDevice(Entity):
@@ -152,9 +155,15 @@ class TahomaDevice(Entity):
 
     async def async_execute_command(self, command_name: str, *args: Any):
         """Execute device command in async context."""
-        exec_id = await self.coordinator.client.execute_command(
-            self.device.deviceurl, Command(command_name, list(args)), "Home Assistant"
-        )
+        try:
+            exec_id = await self.coordinator.client.execute_command(
+                self.device.deviceurl,
+                Command(command_name, list(args)),
+                "Home Assistant",
+            )
+        except Exception as exception:
+            _LOGGER.error(exception)
+            return
 
         # ExecutionRegisteredEvent doesn't contain the deviceurl, thus we need to register it here
         self.coordinator.executions[exec_id] = {

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,4 +7,4 @@ pytest-cov<3.0.0
 pytest-homeassistant
 
 # from our manifest.json for our Custom Component
-pyhoma==0.4.2
+pyhoma==0.4.3


### PR DESCRIPTION
Currently we don't catch exceptions in `async_execute_command`, which means that we could add a faulty exec_id to the executions list. And besides that, we don't show a nice human readable error in the log.