### PR TITLE
Improve error handling on startup

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -86,14 +86,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await client.login()
     except BadCredentialsException:
         _LOGGER.error("invalid_auth")
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                # Change to SOURCE_REAUTH after 116.0 release
-                DOMAIN,
-                context={"source": "reauth"},
-                data=entry.data,
-            )
-        )
         return False
     except TooManyRequestsException as exception:
         _LOGGER.error("too_many_requests")

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -149,23 +149,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     async def handle_execute_command(call):
         """Handle execute command service."""
-
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                # Change to SOURCE_REAUTH after 116.0 release
-                DOMAIN,
-                context={"source": "reauth"},
-                data=entry.data,
-            )
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        entity = entity_registry.entities.get(call.data.get("entity_id"))
+        await tahoma_coordinator.client.execute_command(
+            entity.unique_id,
+            Command(call.data.get("command"), call.data.get("args")),
+            "Home Assistant Service",
         )
-
-        # entity_registry = await hass.helpers.entity_registry.async_get_registry()
-        # entity = entity_registry.entities.get(call.data.get("entity_id"))
-        # await tahoma_coordinator.client.execute_command(
-        #     entity.unique_id,
-        #     Command(call.data.get("command"), call.data.get("args")),
-        #     "Home Assistant Service",
-        # )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -84,6 +84,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     try:
         await client.login()
+        devices = await client.get_devices()
+        scenarios = await client.get_scenarios()
     except BadCredentialsException:
         _LOGGER.error("invalid_auth")
         return False
@@ -104,14 +106,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER,
         name="TaHoma Event Fetcher",
         client=client,
-        devices=await client.get_devices(),
+        devices=devices,
         update_interval=timedelta(seconds=update_interval),
     )
 
     await tahoma_coordinator.async_refresh()
 
     entities = defaultdict(list)
-    entities[SCENE] = await client.get_scenarios()
+    entities[SCENE] = scenarios
 
     hass.data[DOMAIN][entry.entry_id] = {
         "entities": entities,

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -32,6 +32,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self):
+        """Initialize a ConfigFlow."""
+        self._reauth = False
+        super().__init__()
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
@@ -53,7 +58,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input:
             await self.async_set_unique_id(user_input.get(CONF_USERNAME))
-            self._abort_if_unique_id_configured()
+
+            if not self._reauth:
+                self._abort_if_unique_id_configured()
 
             try:
                 return await self.async_validate_input(user_input)
@@ -90,6 +97,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as exception:  # pylint: disable=broad-except
             _LOGGER.exception(exception)
             return self.async_abort(reason="unknown")
+
+    async def async_step_reauth(self, entry_data):
+        """Handle a reauthorization flow request."""
+        self._reauth = True
+        return await self.async_step_user(entry_data)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -32,11 +32,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    def __init__(self):
-        """Initialize a ConfigFlow."""
-        self._reauth = False
-        super().__init__()
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
@@ -58,9 +53,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input:
             await self.async_set_unique_id(user_input.get(CONF_USERNAME))
-
-            if not self._reauth:
-                self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured()
 
             try:
                 return await self.async_validate_input(user_input)
@@ -97,11 +90,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as exception:  # pylint: disable=broad-except
             _LOGGER.exception(exception)
             return self.async_abort(reason="unknown")
-
-    async def async_step_reauth(self, entry_data):
-        """Handle a reauthorization flow request."""
-        self._reauth = True
-        return await self.async_step_user(entry_data)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):


### PR DESCRIPTION
We now raise ConfigEntryNotReady on some exceptions, to make it retry. Not 100% sure if this will work for `too_many_requests` as well.

```
2020-09-29 23:59:35 ERROR (MainThread) [custom_components.tahoma] too_many_requests
2020-09-29 23:59:35 WARNING (MainThread) [homeassistant.config_entries] Config entry for tahoma not ready yet. Retrying in 20 seconds
2020-09-29 23:59:56 ERROR (MainThread) [custom_components.tahoma] too_many_requests
2020-09-29 23:59:56 WARNING (MainThread) [homeassistant.config_entries] Config entry for tahoma not ready yet. Retrying in 40 seconds
2020-09-30 00:00:36 ERROR (MainThread) [custom_components.tahoma] too_many_requests
2020-09-30 00:00:36 WARNING (MainThread) [homeassistant.config_entries] Config entry for tahoma not ready yet. Retrying in 80 seconds
```