### PR TITLE
Fix wrong position for awning valance

### DIFF
--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -190,7 +190,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         # HorizontalAwning devices need a reversed position that can not be obtained via the API
-        if "Horizontal" in self.device.widget:
+        if "Horizontal" in self.device.widget or self.device.widget == "AwningValance":
             position = kwargs.get(ATTR_POSITION, 0)
 
         await self.async_execute_command(

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -157,9 +157,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
         if position is None or position < 0 or position > 100:
             return None
 
-        if not (
-            "Horizontal" in self.device.widget or self.device.widget == "AwningValence"
-        ):
+        if not self._reversed_position_device():
             position = 100 - position
 
         return position
@@ -179,8 +177,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
         """Move the cover to a specific position."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
-        # HorizontalAwning devices need a reversed position that can not be obtained via the API
-        if "Horizontal" in self.device.widget or self.device.widget == "AwningValance":
+        if self._reversed_position_device():
             position = kwargs.get(ATTR_POSITION, 0)
 
         await self.async_execute_command(
@@ -191,8 +188,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
         """Move the cover to a specific position with a low speed."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
-        # HorizontalAwning devices need a reversed position that can not be obtained via the API
-        if "Horizontal" in self.device.widget or self.device.widget == "AwningValance":
+        if self._reversed_position_device():
             position = kwargs.get(ATTR_POSITION, 0)
 
         await self.async_execute_command(
@@ -379,3 +375,9 @@ class TahomaCover(TahomaDevice, CoverEntity):
             supported_features |= SUPPORT_MY
 
         return supported_features
+
+    def _reversed_position_device(self):
+        """Return true if the device need a reversed position that can not be obtained via the API."""
+        return (
+            "Horizontal" in self.device.widget or self.device.widget == "AwningValance"
+        )

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -157,7 +157,9 @@ class TahomaCover(TahomaDevice, CoverEntity):
         if position is None or position < 0 or position > 100:
             return None
 
-        if "Horizontal" not in self.device.widget:
+        if not (
+            "Horizontal" in self.device.widget or self.device.widget == "AwningValence"
+        ):
             position = 100 - position
 
         return position
@@ -178,7 +180,7 @@ class TahomaCover(TahomaDevice, CoverEntity):
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         # HorizontalAwning devices need a reversed position that can not be obtained via the API
-        if "Horizontal" in self.device.widget:
+        if "Horizontal" in self.device.widget or self.device.widget == "AwningValance":
             position = kwargs.get(ATTR_POSITION, 0)
 
         await self.async_execute_command(


### PR DESCRIPTION
Fix #324 

```JSON
{
  "commands": [
    {
      "commandName": "close",
      "nparams": 0
    },
    {
      "commandName": "delayedStopIdentify",
      "nparams": 1
    },
    {
      "commandName": "deploy",
      "nparams": 0
    },
    {
      "commandName": "down",
      "nparams": 0
    },
    {
      "commandName": "getName",
      "nparams": 0
    },
    {
      "commandName": "identify",
      "nparams": 0
    },
    {
      "commandName": "my",
      "nparams": 0
    },
    {
      "commandName": "open",
      "nparams": 0
    },
    {
      "commandName": "refreshMemorized1Position",
      "nparams": 0
    },
    {
      "commandName": "setClosure",
      "nparams": 1
    },
    {
      "commandName": "setDeployment",
      "nparams": 1
    },
    {
      "commandName": "setMemorized1Position",
      "nparams": 1
    },
    {
      "commandName": "setName",
      "nparams": 1
    },
    {
      "commandName": "setPosition",
      "nparams": 1
    },
    {
      "commandName": "setSecuredPosition",
      "nparams": 1
    },
    {
      "commandName": "startIdentify",
      "nparams": 0
    },
    {
      "commandName": "stop",
      "nparams": 0
    },
    {
      "commandName": "stopIdentify",
      "nparams": 0
    },
    {
      "commandName": "undeploy",
      "nparams": 0
    },
    {
      "commandName": "up",
      "nparams": 0
    },
    {
      "commandName": "wink",
      "nparams": 1
    },
    {
      "commandName": "keepOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "pairOneWayController",
      "nparams": 2
    },
    {
      "commandName": "setConfigState",
      "nparams": 1
    },
    {
      "commandName": "unpairAllOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "unpairAllOneWayControllers",
      "nparams": 0
    },
    {
      "commandName": "unpairOneWayController",
      "nparams": 2
    }
  ],
  "states": [
    {
      "type": "ContinuousState",
      "qualifiedName": "core:ClosureState"
    },
    {
      "values": [
        "good",
        "low",
        "normal",
        "verylow"
      ],
      "type": "DiscreteState",
      "qualifiedName": "core:DiscreteRSSILevelState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:Memorized1PositionState"
    },
    {
      "type": "DataState",
      "qualifiedName": "core:NameState"
    },
    {
      "values": [
        "closed",
        "open"
      ],
      "type": "DiscreteState",
      "qualifiedName": "core:OpenClosedState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:PriorityLockTimerState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:RSSILevelState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:SecuredPositionState"
    },
    {
      "values": [
        "available",
        "unavailable"
      ],
      "type": "DiscreteState",
      "qualifiedName": "core:StatusState"
    },
    {
      "values": [
        "comfortLevel1",
        "comfortLevel2",
        "comfortLevel3",
        "comfortLevel4",
        "environmentProtection",
        "humanProtection",
        "userLevel1",
        "userLevel2"
      ],
      "type": "DiscreteState",
      "qualifiedName": "io:PriorityLockLevelState"
    },
    {
      "values": [
        "LSC",
        "SAAC",
        "SFC",
        "UPS",
        "externalGateway",
        "localUser",
        "myself",
        "rain",
        "security",
        "temperature",
        "timer",
        "user",
        "wind"
      ],
      "type": "DiscreteState",
      "qualifiedName": "io:PriorityLockOriginatorState"
    }
  ],
  "dataProperties": [
    {
      "value": "500",
      "qualifiedName": "core:identifyInterval"
    }
  ],
  "widgetName": "AwningValance",
  "uiClass": "Awning",
  "qualifiedName": "io:AwningValanceIOComponent",
  "type": "ACTUATOR"
}
```