### PR TITLE
Make 'execute_command' service an admin service

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pyhoma.client import TahomaClient
 from pyhoma.exceptions import (
@@ -183,7 +183,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "Home Assistant Service",
         )
 
-    hass.services.async_register_admin_service(
+    service.async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_EXECUTE_COMMAND,
         handle_execute_command,

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -183,7 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "Home Assistant Service",
         )
 
-    hass.services.async_register(
+    hass.services.async_register_admin_service(
         DOMAIN,
         SERVICE_EXECUTE_COMMAND,
         handle_execute_command,


### PR DESCRIPTION
Execute Command is a very powerful service and should only be accessible to admins.

