### PR TITLE
Add service to retrieve execution history

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,22 @@ logger:
     custom_components.tahoma: debug
 ```
 
-### Device not supported / working correctly
+### Device not supported
 
 If your device is not visible in the device list of Home Assistant (/config/devices/dashboard), you need to turn on [debug logging](#enable-debug-logging). Copy the debug string from your log and create a [new issue](https://github.com/iMicknl/ha-tahoma/issues/new/choose)
 
 `DEBUG (MainThread) [custom_components.tahoma] Unsupported TaHoma device (io:DimmableLightIOComponent - Light - DimmableLight).`
 
+### Device not working correctly
+
 If your device is listed in the device list, create a [new issue](https://github.com/iMicknl/ha-tahoma/issues/new/choose) and fill in all details of the issue template.
+
+In order to gather more information, you can use the `tahoma.get_execution_history` service which will print your execution history to the Home Assistant log. Run the commands via the official vendor (e.g. TaHoma) app and capture the commands.
+
+```
+2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 21:30:00: off executed via Home Assistant on io://xxxx, with [].
+2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 16:23:29: setIntensity executed via Home Assistant on io://xxxx, with [70].
+```
 
 ### Exclude devices
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If your device is not visible in the device list of Home Assistant (/config/devi
 
 If your device is listed in the device list, create a [new issue](https://github.com/iMicknl/ha-tahoma/issues/new/choose) and fill in all details of the issue template.
 
-In order to gather more information, you can use the `tahoma.get_execution_history` service which will print your execution history to the Home Assistant log. Run the commands via the official vendor (e.g. TaHoma) app and capture the commands.
+In order to gather more information, you can use the `tahoma.get_execution_history` service which will print your execution history to the Home Assistant log. Run the commands via the official vendor app (e.g. TaHoma) and capture the commands.
 
 ```
 2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 21:30:00: off executed via Home Assistant on io://xxxx, with [].

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -1,7 +1,7 @@
 """The TaHoma integration."""
 import asyncio
 from collections import defaultdict
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum
 import logging
 
@@ -235,6 +235,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             sw_version=gateway.connectivity.protocol_version,
         )
 
+    async def handle_get_execution_history(call):
+        """Handle get execution history service."""
+        await write_execution_history_to_log(tahoma_coordinator.client)
+
+    service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        "get_execution_history",
+        handle_get_execution_history,
+    )
+
     return True
 
 
@@ -276,6 +287,27 @@ def print_homekit_setup_code(device: Device):
 
         if homekit:
             _LOGGER.info("HomeKit support detected with setup code %s.", homekit.value)
+
+
+async def write_execution_history_to_log(client: TahomaClient):
+    """Retrieve execution history and write output to log."""
+    history = await client.get_execution_history()
+
+    for item in history:
+        timestamp = datetime.fromtimestamp(int(item.event_time) / 1000)
+
+        for command in item.commands:
+            date = timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+            _LOGGER.info(
+                "{timestamp}: {command} executed via {app} on {device}, with {parameters}.".format(
+                    command=command.command,
+                    timestamp=date,
+                    device=command.deviceurl,
+                    parameters=command.parameters,
+                    app=item.label,
+                )
+            )
 
 
 def beautify_name(name: str):

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -319,11 +319,6 @@ def print_homekit_setup_code(device: Device):
             _LOGGER.info("HomeKit support detected with setup code %s.", homekit.value)
 
 
-def beautify_name(name: str):
-    """Return human readable string."""
-    return name.replace("_", " ").title()
-
-
 async def write_execution_history_to_log(client: TahomaClient):
     """Retrieve execution history and write output to log."""
     history = await client.get_execution_history()

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.5.4"
+    "pyhoma==0.5.5"
   ],
   "codeowners": [
     "@philklei",

--- a/custom_components/tahoma/services.yaml
+++ b/custom_components/tahoma/services.yaml
@@ -34,3 +34,6 @@ execute_command:
     args:
       description: List of arguments to pass to the command if necessary
       example: 100
+
+get_execution_history:
+  description: Retrieve execution history and write output to log.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,4 +7,4 @@ pytest-cov<3.0.0
 pytest-homeassistant
 
 # from our manifest.json for our Custom Component
-pyhoma==0.5.4
+pyhoma==0.5.5


### PR DESCRIPTION
```
2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 21:30:00: off executed via Home Assistant on io://xxxx, with [].
2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 16:23:29: setIntensity executed via Home Assistant on io://xxxx, with [70].
2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-27 16:23:29: closeSlats executed via Home Assistant on io://xxxx, with [].
2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-26 21:30:00: off executed via Home Assistant on io://xxxx, with [].
2021-01-28 09:20:22 INFO (MainThread) [custom_components.tahoma] 2021-01-26 16:21:43: setIntensity executed via Home Assistant on io://xxxx, with [70].
```

I don't think this one should be added to the core integration eventually, but it will make our life way easier for now. This will enable users to print their execution log, so that we can capture commands they took from the official apps.

The date is not the right timezone for most users, but I don't think that will be an issue?