### PR TITLE
Improve issue templates, adding the Hub used

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
 
-- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Regl, Somfy Connexoon, Somfy TaHoma]
+- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Rexel, Somfy Connexoon, Somfy TaHoma]
 - **ha-tahoma version:** [e.g. 2.0.0]
 - **Home Assistant version:** [e.g. 0.110.4]
 - **Platform**: [e.g. cover, sensor, binary_sensor]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
 
+- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Regl, Somfy Connexoon, Somfy TaHoma]
 - **ha-tahoma version:** [e.g. 2.0.0]
 - **Home Assistant version:** [e.g. 0.110.4]
 - **Platform**: [e.g. cover, sensor, binary_sensor]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: enhancement
 assignees: ''
 
 ---
-- [ ] **I have read the [readme](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [Advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
+- [ ] **I have read the [README](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [Advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: enhancement
 assignees: ''
 
 ---
-- [ ] **I have read the [Readme](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [Advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
+- [ ] **I have read the [readme](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [Advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/unsupported-device.md
+++ b/.github/ISSUE_TEMPLATE/unsupported-device.md
@@ -1,11 +1,11 @@
 ---
 name: Unsupported device
 about: Let's have a look if we can add support for your device to this component
-title: Add support for [ModelName] (io:SomfySensorName)
+title: Add support for ModelName (io:SomfySensorName)
 labels: new-device
 assignees: ""
 ---
-- [ ] **I have read the [Readme](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [Advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
+- [ ] **I have read the [README](https://github.com/iMicknl/ha-tahoma/blob/master/README.md), including the [advanced](https://github.com/iMicknl/ha-tahoma/blob/master/README.md#advanced) section regarding debugging.**
 
 <!--
 Please update the title to match your device model and type
@@ -14,10 +14,19 @@ Please update the title to match your device model and type
 **Device information**
 A clear and concise description of the device, together with specific usecases that you would like to see supported.
 
+
 **Device details**
 
-<!--
-Enable debug logging (https://github.com/iMicknl/ha-tahoma#enable-debug-logging) and paste the Unsupported Tahoma device string here.
+- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Regl, Somfy Connexoon, Somfy TaHoma]
 
-If your device already shows up in Home Assistant, share the type (e.g. `io:DimmableLightIOComponent`), which can be gathered from device page in HA looking at Firmware] `/config/devices/dashboard`
+<!--
+Enable debug logging (https://github.com/iMicknl/ha-tahoma#enable-debug-logging) and paste the Unsupported device string here.
+
+If your device already shows up in Home Assistant, share the type (e.g. `io:DimmableLightIOComponent`, which can be gathered from device page in HA looking at Firmware] `/config/devices/dashboard`
+-->
+
+**Device commands**
+<!--
+In order to gather more information, you can use the tahoma.get_execution_history service which will print your execution history to the Home Assistant log. Run the commands via the official vendor app (e.g. TaHoma) and capture the commands.
+https://github.com/iMicknl/ha-tahoma#device-not-working-correctly
 -->

--- a/.github/ISSUE_TEMPLATE/unsupported-device.md
+++ b/.github/ISSUE_TEMPLATE/unsupported-device.md
@@ -17,7 +17,7 @@ A clear and concise description of the device, together with specific usecases t
 
 **Device details**
 
-- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Regl, Somfy Connexoon, Somfy TaHoma]
+- **Hub**: [e.g. Cozytouch, eedoums, Hi Kumo, Rexel, Somfy Connexoon, Somfy TaHoma]
 
 <!--
 Enable debug logging (https://github.com/iMicknl/ha-tahoma#enable-debug-logging) and paste the Unsupported device string here.


### PR DESCRIPTION
Since we have now support for multiple hubs, it would be good to understand which hub people are using.