### PR TITLE
Remove code dedicated to gate opener

### DIFF
--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -43,7 +43,6 @@ COMMAND_OPEN_SLATS = "openSlats"
 COMMAND_SET_CLOSURE = "setClosure"
 COMMAND_SET_DEPLOYMENT = "setDeployment"
 COMMAND_SET_ORIENTATION = "setOrientation"
-COMMAND_SET_PEDESTRIAN_POSITION = "setPedestrianPosition"
 COMMAND_SET_POSITION = "setPosition"
 COMMAND_SET_POSITION_AND_LINEAR_SPEED = "setPositionAndLinearSpeed"
 COMMAND_STOP = "stop"
@@ -60,7 +59,6 @@ COMMANDS_CLOSE_TILT = [COMMAND_CLOSE_SLATS]
 COMMANDS_SET_POSITION = [
     COMMAND_SET_POSITION,
     COMMAND_SET_CLOSURE,
-    COMMAND_SET_PEDESTRIAN_POSITION,
 ]
 COMMANDS_SET_TILT_POSITION = [COMMAND_SET_ORIENTATION]
 
@@ -69,10 +67,8 @@ CORE_CLOSURE_OR_ROCKER_POSITION_STATE = "core:ClosureOrRockerPositionState"
 CORE_DEPLOYMENT_STATE = "core:DeploymentState"
 CORE_MEMORIZED_1_POSITION_STATE = "core:Memorized1PositionState"
 CORE_OPEN_CLOSED_PARTIAL_STATE = "core:OpenClosedPartialState"
-CORE_OPEN_CLOSED_PEDESTRIAN_STATE = "core:OpenClosedPedestrianState"
 CORE_OPEN_CLOSED_STATE = "core:OpenClosedState"
 CORE_OPEN_CLOSED_UNKNOWN_STATE = "core:OpenClosedUnknownState"
-CORE_PEDESTRIAN_POSITION_STATE = "core:PedestrianPositionState"
 CORE_PRIORITY_LOCK_TIMER_STATE = "core:PriorityLockTimerState"
 CORE_SLATS_OPEN_CLOSED_STATE = "core:SlatsOpenClosedState"
 CORE_SLATE_ORIENTATION_STATE = "core:SlateOrientationState"
@@ -157,7 +153,6 @@ class TahomaCover(TahomaEntity, CoverEntity):
 
         position = self.select_state(
             CORE_CLOSURE_STATE,
-            CORE_PEDESTRIAN_POSITION_STATE,
             CORE_TARGET_CLOSURE_STATE,
             CORE_CLOSURE_OR_ROCKER_POSITION_STATE,
         )
@@ -213,7 +208,6 @@ class TahomaCover(TahomaEntity, CoverEntity):
             CORE_OPEN_CLOSED_STATE,
             CORE_SLATS_OPEN_CLOSED_STATE,
             CORE_OPEN_CLOSED_PARTIAL_STATE,
-            CORE_OPEN_CLOSED_PEDESTRIAN_STATE,
             CORE_OPEN_CLOSED_UNKNOWN_STATE,
             MYFOX_SHUTTER_STATUS_STATE,
         )


### PR DESCRIPTION
This device behaves like a cover (use closure state). There is no need to have code dedicated to it.

```json
{
  "commands": [
    {
      "commandName": "advancedRefresh",
      "nparams": 1
    },
    {
      "commandName": "close",
      "nparams": 0
    },
    {
      "commandName": "delayedStopIdentify",
      "nparams": 1
    },
    {
      "commandName": "getName",
      "nparams": 0
    },
    {
      "commandName": "identify",
      "nparams": 0
    },
    {
      "commandName": "open",
      "nparams": 0
    },
    {
      "commandName": "refreshPedestrianPosition",
      "nparams": 0
    },
    {
      "commandName": "setClosure",
      "nparams": 1
    },
    {
      "commandName": "setClosureOrPedestrianPosition",
      "nparams": 1
    },
    {
      "commandName": "setDeployment",
      "nparams": 1
    },
    {
      "commandName": "setName",
      "nparams": 1
    },
    {
      "commandName": "setPedestrianPosition",
      "nparams": 0
    },
    {
      "commandName": "startIdentify",
      "nparams": 0
    },
    {
      "commandName": "stop",
      "nparams": 0
    },
    {
      "commandName": "stopIdentify",
      "nparams": 0
    },
    {
      "commandName": "wink",
      "nparams": 1
    },
    {
      "commandName": "runManufacturerSettingsCommand",
      "nparams": 2
    },
    {
      "commandName": "keepOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "pairOneWayController",
      "nparams": 2
    },
    {
      "commandName": "sendIOKey",
      "nparams": 0
    },
    {
      "commandName": "setConfigState",
      "nparams": 1
    },
    {
      "commandName": "unpairAllOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "unpairAllOneWayControllers",
      "nparams": 0
    },
    {
      "commandName": "unpairOneWayController",
      "nparams": 2
    }
  ],
  "states": [
    {
      "type": "DataState",
      "qualifiedName": "core:AdditionalStatusState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:ClosureState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "good",
        "low",
        "normal",
        "verylow"
      ],
      "qualifiedName": "core:DiscreteRSSILevelState"
    },
    {
      "type": "DataState",
      "qualifiedName": "core:ManufacturerSettingsState"
    },
    {
      "type": "DataState",
      "qualifiedName": "core:NameState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "closed",
        "open",
        "pedestrian",
        "unknown"
      ],
      "qualifiedName": "core:OpenClosedPedestrianState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:PedestrianPositionState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:PriorityLockTimerState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:RSSILevelState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "available",
        "unavailable"
      ],
      "qualifiedName": "core:StatusState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "comfortLevel1",
        "comfortLevel2",
        "comfortLevel3",
        "comfortLevel4",
        "environmentProtection",
        "humanProtection",
        "userLevel1",
        "userLevel2"
      ],
      "qualifiedName": "io:PriorityLockLevelState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "LSC",
        "SAAC",
        "SFC",
        "UPS",
        "externalGateway",
        "localUser",
        "myself",
        "rain",
        "security",
        "temperature",
        "timer",
        "user",
        "wind"
      ],
      "qualifiedName": "io:PriorityLockOriginatorState"
    }
  ],
  "dataProperties": [
    {
      "value": "500",
      "qualifiedName": "core:identifyInterval"
    }
  ],
  "widgetName": "PositionableGateWithPedestrianPosition",
  "uiProfiles": [
    "StatefulCloseableGateOpener",
    "StatefulCloseable",
    "Closeable",
    "OpenClose"
  ],
  "uiClass": "Gate",
  "qualifiedName": "io:GateOpenerIOComponent",
  "type": "ACTUATOR"
}
```