### PR TITLE
Remove setPosition

### DIFF
--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -41,9 +41,9 @@ COMMAND_MY = "my"
 COMMAND_OPEN = "open"
 COMMAND_OPEN_SLATS = "openSlats"
 COMMAND_SET_CLOSURE = "setClosure"
+COMMAND_SET_CLOSURE_AND_LINEAR_SPEED = "setClosureAndLinearSpeed"
 COMMAND_SET_DEPLOYMENT = "setDeployment"
 COMMAND_SET_ORIENTATION = "setOrientation"
-COMMAND_SET_POSITION_AND_LINEAR_SPEED = "setPositionAndLinearSpeed"
 COMMAND_STOP = "stop"
 COMMAND_STOP_IDENTIFY = "stopIdentify"
 COMMAND_UNDEPLOY = "undeploy"
@@ -184,7 +184,7 @@ class TahomaCover(TahomaEntity, CoverEntity):
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         await self.async_execute_command(
-            COMMAND_SET_POSITION_AND_LINEAR_SPEED, position, "lowspeed"
+            COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed"
         )
 
     async def async_set_cover_tilt_position(self, **kwargs):
@@ -378,7 +378,7 @@ class TahomaCover(TahomaEntity, CoverEntity):
         if self.has_command(*COMMANDS_CLOSE) or self.has_command(COMMAND_UNDEPLOY):
             supported_features |= SUPPORT_CLOSE
 
-        if self.has_command(COMMAND_SET_POSITION_AND_LINEAR_SPEED):
+        if self.has_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED):
             supported_features |= SUPPORT_COVER_POSITION_LOW_SPEED
 
         if self.has_command(COMMAND_MY):

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -1,6 +1,4 @@
 """Support for TaHoma cover - shutters etc."""
-import logging
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -27,8 +25,6 @@ import voluptuous as vol
 
 from .const import DOMAIN
 from .tahoma_entity import TahomaEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 ATTR_OBSTRUCTION_DETECTED = "obstruction-detected"
 

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -43,7 +43,6 @@ COMMAND_OPEN_SLATS = "openSlats"
 COMMAND_SET_CLOSURE = "setClosure"
 COMMAND_SET_DEPLOYMENT = "setDeployment"
 COMMAND_SET_ORIENTATION = "setOrientation"
-COMMAND_SET_POSITION = "setPosition"
 COMMAND_SET_POSITION_AND_LINEAR_SPEED = "setPositionAndLinearSpeed"
 COMMAND_STOP = "stop"
 COMMAND_STOP_IDENTIFY = "stopIdentify"
@@ -56,10 +55,7 @@ COMMANDS_OPEN = [COMMAND_OPEN, COMMAND_UP, COMMAND_CYCLE]
 COMMANDS_OPEN_TILT = [COMMAND_OPEN_SLATS]
 COMMANDS_CLOSE = [COMMAND_CLOSE, COMMAND_DOWN, COMMAND_CYCLE]
 COMMANDS_CLOSE_TILT = [COMMAND_CLOSE_SLATS]
-COMMANDS_SET_POSITION = [
-    COMMAND_SET_POSITION,
-    COMMAND_SET_CLOSURE,
-]
+
 COMMANDS_SET_TILT_POSITION = [COMMAND_SET_ORIENTATION]
 
 CORE_CLOSURE_STATE = "core:ClosureState"
@@ -181,9 +177,7 @@ class TahomaCover(TahomaEntity, CoverEntity):
             await self.async_execute_command(COMMAND_SET_DEPLOYMENT, position)
         else:
             position = 100 - kwargs.get(ATTR_POSITION, 0)
-            await self.async_execute_command(
-                self.select_command(*COMMANDS_SET_POSITION), position
-            )
+            await self.async_execute_command(COMMAND_SET_CLOSURE, position)
 
     async def async_set_cover_position_low_speed(self, **kwargs):
         """Move the cover to a specific position with a low speed."""
@@ -269,7 +263,7 @@ class TahomaCover(TahomaEntity, CoverEntity):
     async def async_stop_cover(self, **_):
         """Stop the cover."""
         await self.async_cancel_or_stop_cover(
-            COMMANDS_OPEN + COMMANDS_SET_POSITION + COMMANDS_CLOSE,
+            COMMANDS_OPEN + [COMMAND_SET_CLOSURE] + COMMANDS_CLOSE,
             COMMANDS_STOP,
         )
 
@@ -370,7 +364,7 @@ class TahomaCover(TahomaEntity, CoverEntity):
         if self.has_command(*COMMANDS_SET_TILT_POSITION):
             supported_features |= SUPPORT_SET_TILT_POSITION
 
-        if self.has_command(*COMMANDS_SET_POSITION) or self.has_command(
+        if self.has_command(COMMAND_SET_CLOSURE) or self.has_command(
             COMMAND_SET_DEPLOYMENT
         ):
             supported_features |= SUPPORT_SET_POSITION


### PR DESCRIPTION
When setPosition is available, there is always setClosure. For instance:

```
{
  "commands": [
    {
      "commandName": "advancedRefresh",
      "nparams": 1
    },
    {
      "commandName": "close",
      "nparams": 0
    },
    {
      "commandName": "delayedStopIdentify",
      "nparams": 1
    },
    {
      "commandName": "deploy",
      "nparams": 0
    },
    {
      "commandName": "down",
      "nparams": 0
    },
    {
      "commandName": "getName",
      "nparams": 0
    },
    {
      "commandName": "identify",
      "nparams": 0
    },
    {
      "commandName": "my",
      "nparams": 0
    },
    {
      "commandName": "open",
      "nparams": 0
    },
    {
      "commandName": "refreshMemorized1Position",
      "nparams": 0
    },
    {
      "commandName": "setClosure",
      "nparams": 1
    },
    {
      "commandName": "setDeployment",
      "nparams": 1
    },
    {
      "commandName": "setMemorized1Position",
      "nparams": 1
    },
    {
      "commandName": "setName",
      "nparams": 1
    },
    {
      "commandName": "setPosition",
      "nparams": 1
    },
    {
      "commandName": "setSecuredPosition",
      "nparams": 1
    },
    {
      "commandName": "startIdentify",
      "nparams": 0
    },
    {
      "commandName": "stop",
      "nparams": 0
    },
    {
      "commandName": "stopIdentify",
      "nparams": 0
    },
    {
      "commandName": "undeploy",
      "nparams": 0
    },
    {
      "commandName": "up",
      "nparams": 0
    },
    {
      "commandName": "wink",
      "nparams": 1
    },
    {
      "commandName": "runManufacturerSettingsCommand",
      "nparams": 2
    },
    {
      "commandName": "keepOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "pairOneWayController",
      "nparams": 2
    },
    {
      "commandName": "setConfigState",
      "nparams": 1
    },
    {
      "commandName": "unpairAllOneWayControllersAndDeleteNode",
      "nparams": 0
    },
    {
      "commandName": "unpairAllOneWayControllers",
      "nparams": 0
    },
    {
      "commandName": "unpairOneWayController",
      "nparams": 2
    }
  ],
  "states": [
    {
      "type": "ContinuousState",
      "qualifiedName": "core:ClosureState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "good",
        "low",
        "normal",
        "verylow"
      ],
      "qualifiedName": "core:DiscreteRSSILevelState"
    },
    {
      "type": "DataState",
      "qualifiedName": "core:ManufacturerSettingsState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:Memorized1PositionState"
    },
    {
      "type": "DataState",
      "qualifiedName": "core:NameState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "closed",
        "open"
      ],
      "qualifiedName": "core:OpenClosedState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:PriorityLockTimerState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:RSSILevelState"
    },
    {
      "type": "ContinuousState",
      "qualifiedName": "core:SecuredPositionState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "available",
        "unavailable"
      ],
      "qualifiedName": "core:StatusState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "comfortLevel1",
        "comfortLevel2",
        "comfortLevel3",
        "comfortLevel4",
        "environmentProtection",
        "humanProtection",
        "userLevel1",
        "userLevel2"
      ],
      "qualifiedName": "io:PriorityLockLevelState"
    },
    {
      "type": "DiscreteState",
      "values": [
        "LSC",
        "SAAC",
        "SFC",
        "UPS",
        "externalGateway",
        "localUser",
        "myself",
        "rain",
        "security",
        "temperature",
        "timer",
        "user",
        "wind"
      ],
      "qualifiedName": "io:PriorityLockOriginatorState"
    }
  ],
  "dataProperties": [
    {
      "value": "500",
      "qualifiedName": "core:identifyInterval"
    }
  ],
  "widgetName": "AwningValance",
  "uiProfiles": [
    "DeployableAwning",
    "Deployable",
    "DeployUndeploy",
    "StatefulCloseable",
    "StatefulOpenClose",
    "OpenClose"
  ],
  "uiClass": "Awning",
  "qualifiedName": "io:AwningValanceIOComponent",
  "type": "ACTUATOR"
}
```

Same remark for setPositionAndLinearSpeed and setClosureAndLinearSpeed:

```
{
	"commands": [{
		"commandName": "close",
		"nparams": 0
	}, {
		"commandName": "delayedStopIdentify",
		"nparams": 1
	}, {
		"commandName": "down",
		"nparams": 0
	}, {
		"commandName": "getName",
		"nparams": 0
	}, {
		"commandName": "identify",
		"nparams": 0
	}, {
		"commandName": "my",
		"nparams": 0
	}, {
		"commandName": "open",
		"nparams": 0
	}, {
		"commandName": "refreshMemorized1Position",
		"nparams": 0
	}, {
		"commandName": "setClosureAndLinearSpeed",
		"nparams": 2
	}, {
		"commandName": "setClosure",
		"nparams": 1
	}, {
		"commandName": "setDeployment",
		"nparams": 1
	}, {
		"commandName": "setMemorized1Position",
		"nparams": 1
	}, {
		"commandName": "setName",
		"nparams": 1
	}, {
		"commandName": "setPositionAndLinearSpeed",
		"nparams": 2
	}, {
		"commandName": "setPosition",
		"nparams": 1
	}, {
		"commandName": "setSecuredPosition",
		"nparams": 1
	}, {
		"commandName": "startIdentify",
		"nparams": 0
	}, {
		"commandName": "stop",
		"nparams": 0
	}, {
		"commandName": "stopIdentify",
		"nparams": 0
	}, {
		"commandName": "up",
		"nparams": 0
	}, {
		"commandName": "wink",
		"nparams": 1
	}, {
		"commandName": "pairOneWayController",
		"nparams": 2
	}, {
		"commandName": "unpairAllOneWayControllers",
		"nparams": 0
	}, {
		"commandName": "unpairOneWayController",
		"nparams": 2
	}],
	"states": [{
		"type": "ContinuousState",
		"qualifiedName": "core:ClosureState"
	}, {
		"values": ["good", "low", "normal", "verylow"],
		"type": "DiscreteState",
		"qualifiedName": "core:DiscreteRSSILevelState"
	}, {
		"type": "ContinuousState",
		"qualifiedName": "core:Memorized1PositionState"
	}, {
		"type": "DataState",
		"qualifiedName": "core:NameState"
	}, {
		"values": ["closed", "open"],
		"type": "DiscreteState",
		"qualifiedName": "core:OpenClosedState"
	}, {
		"type": "ContinuousState",
		"qualifiedName": "core:PriorityLockTimerState"
	}, {
		"type": "ContinuousState",
		"qualifiedName": "core:RSSILevelState"
	}, {
		"type": "ContinuousState",
		"qualifiedName": "core:SecuredPositionState"
	}, {
		"values": ["available", "unavailable"],
		"type": "DiscreteState",
		"qualifiedName": "core:StatusState"
	}, {
		"values": ["comfortLevel1", "comfortLevel2", "comfortLevel3", "comfortLevel4", "environmentProtection", "humanProtection", "userLevel1", "userLevel2"],
		"type": "DiscreteState",
		"qualifiedName": "io:PriorityLockLevelState"
	}, {
		"values": ["LSC", "SAAC", "SFC", "UPS", "externalGateway", "localUser", "myself", "rain", "security", "temperature", "timer", "user", "wind"],
		"type": "DiscreteState",
		"qualifiedName": "io:PriorityLockOriginatorState"
	}],
	"dataProperties": [{
		"value": "500",
		"qualifiedName": "core:identifyInterval"
	}],
	"widgetName": "PositionableRollerShutterWithLowSpeedManagement",
	"uiClass": "RollerShutter",
	"qualifiedName": "io:RollerShutterWithLowSpeedManagementIOComponent",
	"type": "ACTUATOR"
}
```