### PR TITLE
Add TaHoma switch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Custom component for Home Assistant to interact with smart devices via the Somfy
 ## Supported hubs
 
 - Somfy TaHoma Box
+- Somfy TaHoma switch
 - Somfy Connexoon IO
 - Somfy Connexoon RTS
 - Cozytouch

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -21,6 +21,7 @@ SUPPORTED_ENDPOINTS = {
     "Somfy Connexoon IO": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
     "Somfy Connexoon RTS": "https://ha201-1.overkiz.com/enduser-mobile-web/enduserAPI/",
     "Somfy TaHoma": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+    "Somfy TaHoma switch": "https://ha101-1.overkiz.com/enduser-mobile-web/enduserAPI/",
 }
 
 HUB_MANUFACTURER = {
@@ -31,6 +32,7 @@ HUB_MANUFACTURER = {
     "Somfy Connexoon IO": "Somfy",
     "Somfy Connexoon RTS": "Somfy",
     "Somfy TaHoma": "Somfy",
+    "Somfy TaHoma switch": "Somfy",
 }
 
 MIN_UPDATE_INTERVAL = 30


### PR DESCRIPTION
After reverse engineering the android app, I found out that the endpoint used by "TaHoma switch" was the same as eedomus one.

This PR add "TaHoma switch" option to the UI and so let user select it. User have to enter same login information that he use on the app.

Tested on my side with protocols io and rts (thank you!).

![image](https://user-images.githubusercontent.com/11361874/120801070-fee60b80-c540-11eb-8a8d-d5177669320f.png)

