### PR TITLE
Added examples how to use the new services

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tap_action:
   action: call-service
   service: tahoma.set_cover_my_position
   service_data:
-    entity_id: cover.gaestezimmer_1
+    entity_id: cover.gaestezimmer_1 # add your entity id here.
 ``` 
 This will move the cover with normal speed to the "My Position" (if supported).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cover:
           target:
             entity_id: cover.your_cover
           data:
-            position: 20
+            position: 0
 ```
 Then add in your UI a button card calling the entity `cover.your_cover_slow`.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,43 @@ This integration is included in HACS. Search for the `Somfy TaHoma` integration 
 
 ## Advanced
 
+### Examples
+#### Using a template_cover
+If your cover supports the slow moving mode you can create template_covers to move the cover always in the slow mode. Add in `configuration.yaml` the following code, replacing the `cover.your_cover` with your entity name:
+```yml
+cover:
+  - platform: template
+    covers:
+      your_cover_slow:
+        friendly_name: "Your cover slow"
+        open_cover:
+          service: tahoma.set_cover_position_low_speed
+          target:
+            entity_id: cover.your_cover
+          data:
+            position: 100
+        close_cover:    
+          service: tahoma.set_cover_position_low_speed
+          target:
+            entity_id: cover.your_cover
+          data:
+            position: 20
+```
+Then add in your UI a button card calling the entity `cover.your_cover_slow`.
+
+#### Using the custom:button-card
+If you have HACS installed you can use the [button-card](https://github.com/custom-cards/button-card) to open and close your covers calling the new services. Create a new `button-card` in your UI and add the following code:
+```yml
+type: custom:button-card
+icon: mdi:window-open
+tap_action:
+  action: call-service
+  service: tahoma.set_cover_my_position
+  service_data:
+    entity_id: cover.gaestezimmer_1
+``` 
+This will move the cover with normal speed to the "My Position" (if supported).
+
 ### Enable debug logging
 
 The [logger](https://www.home-assistant.io/integrations/logger/) integration lets you define the level of logging activities in Home Assistant. Turning on debug mode will show more information about unsupported devices in your logbook.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cover:
 ```
 Then add in your UI a button card calling the entity `cover.your_cover_slow`.
 
-#### Using the custom:button-card
+#### Map the 'my button' to a Home Assistant button
 If you have HACS installed you can use the [button-card](https://github.com/custom-cards/button-card) to open and close your covers calling the new services. Create a new `button-card` in your UI and add the following code:
 ```yml
 type: custom:button-card

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This integration is included in HACS. Search for the `Somfy TaHoma` integration 
 ## Advanced
 
 ### Examples
-#### Using a template_cover
+#### Use a template cover to control your cover with low speed
 If your cover supports the slow moving mode you can create template_covers to move the cover always in the slow mode. Add in `configuration.yaml` the following code, replacing the `cover.your_cover` with your entity name:
 ```yml
 cover:


### PR DESCRIPTION
Added a template_cover and also an example for the `custom:button-card` for directly usage in lovelace. The link in "Supported devices" does point directly to the repo. Is there a document missing? I think we should fix this. Right now it is more confusing than helping ...