### PR TITLE
Add low speed switch entity

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -209,7 +209,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     supported_platforms = set(platforms.keys())
 
     # Sensor and Binary Sensor will be added dynamically, based on the device states
-    # Required to load the low speed switch
+    # Switch will be added dynamically, based on device features (e.g. low speed cover switch)
     supported_platforms.update((BINARY_SENSOR, SENSOR, SWITCH))
     for platform in supported_platforms:
         hass.async_create_task(

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -9,6 +9,7 @@ from aiohttp import ClientError, ServerDisconnectedError
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
 from homeassistant.components.scene import DOMAIN as SCENE
 from homeassistant.components.sensor import DOMAIN as SENSOR
+from homeassistant.components.switch import DOMAIN as SWITCH
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -208,8 +209,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     supported_platforms = set(platforms.keys())
 
     # Sensor and Binary Sensor will be added dynamically, based on the device states
+    # Required to load the low speed switch
     supported_platforms.add(BINARY_SENSOR)
     supported_platforms.add(SENSOR)
+    supported_platforms.add(SWITCH)
 
     for platform in supported_platforms:
         hass.async_create_task(

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -210,10 +210,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Sensor and Binary Sensor will be added dynamically, based on the device states
     # Required to load the low speed switch
-    supported_platforms.add(BINARY_SENSOR)
-    supported_platforms.add(SENSOR)
-    supported_platforms.add(SWITCH)
-
+    supported_platforms.update((BINARY_SENSOR, SENSOR, SWITCH))
     for platform in supported_platforms:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)

--- a/custom_components/tahoma/cover_devices/tahoma_cover.py
+++ b/custom_components/tahoma/cover_devices/tahoma_cover.py
@@ -1,5 +1,6 @@
 """Base class for TaHoma covers, shutters, awnings, etc."""
 import logging
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,

--- a/custom_components/tahoma/cover_devices/tahoma_cover.py
+++ b/custom_components/tahoma/cover_devices/tahoma_cover.py
@@ -1,4 +1,5 @@
 """Base class for TaHoma covers, shutters, awnings, etc."""
+import logging
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -75,6 +76,8 @@ SERVICE_COVER_POSITION_LOW_SPEED = "set_cover_position_low_speed"
 SUPPORT_MY = 512
 SUPPORT_COVER_POSITION_LOW_SPEED = 1024
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class TahomaGenericCover(OverkizEntity, CoverEntity):
     """Representation of a TaHoma Cover."""
@@ -92,6 +95,10 @@ class TahomaGenericCover(OverkizEntity, CoverEntity):
 
     async def async_set_cover_position_low_speed(self, **kwargs):
         """Move the cover to a specific position with a low speed."""
+        _LOGGER.warning(
+            "This service will removed in the next releases. Use instead the low speed switch."
+        )
+
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         await self.executor.async_execute_command(

--- a/custom_components/tahoma/cover_devices/tahoma_cover.py
+++ b/custom_components/tahoma/cover_devices/tahoma_cover.py
@@ -97,7 +97,7 @@ class TahomaGenericCover(OverkizEntity, CoverEntity):
     async def async_set_cover_position_low_speed(self, **kwargs):
         """Move the cover to a specific position with a low speed."""
         _LOGGER.warning(
-            "This service will removed in the next releases. Use instead the low speed switch."
+            "This service will be removed in Setptember 2021. Use instead the low speed switch."
         )
 
         position = 100 - kwargs.get(ATTR_POSITION, 0)

--- a/custom_components/tahoma/cover_devices/tahoma_cover.py
+++ b/custom_components/tahoma/cover_devices/tahoma_cover.py
@@ -1,6 +1,4 @@
 """Base class for TaHoma covers, shutters, awnings, etc."""
-import logging
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -77,8 +75,6 @@ SERVICE_COVER_POSITION_LOW_SPEED = "set_cover_position_low_speed"
 SUPPORT_MY = 512
 SUPPORT_COVER_POSITION_LOW_SPEED = 1024
 
-_LOGGER = logging.getLogger(__name__)
-
 
 class TahomaGenericCover(OverkizEntity, CoverEntity):
     """Representation of a TaHoma Cover."""
@@ -96,10 +92,6 @@ class TahomaGenericCover(OverkizEntity, CoverEntity):
 
     async def async_set_cover_position_low_speed(self, **kwargs):
         """Move the cover to a specific position with a low speed."""
-        _LOGGER.warning(
-            "This service will be removed in Setptember 2021. Use instead the low speed switch."
-        )
-
         position = 100 - kwargs.get(ATTR_POSITION, 0)
 
         await self.executor.async_execute_command(

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -137,6 +137,9 @@ class VerticalCover(TahomaGenericCover):
 
     def is_low_speed_enabled(self):
         """Return if low speed mode is enabled."""
+        if not self.executor.has_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED):
+            return False
+        
         switch_entity_id = f"{self.entity_id.replace('cover', 'switch')}_low_speed"
         low_speed_entity = self.coordinator.hass.states.get(switch_entity_id)
         return low_speed_entity.state == STATE_ON if low_speed_entity else False

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -13,6 +13,7 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
 )
+from homeassistant.const import STATE_ON
 
 from .tahoma.cover_devices.tahoma_cover import (
     COMMAND_SET_CLOSURE_AND_LINEAR_SPEED,
@@ -132,4 +133,4 @@ class VerticalCover(TahomaGenericCover):
         """Return if low speed mode is enabled."""
         switch_entity_id = f"{self.entity_id.replace('cover', 'switch')}_low_speed"
         low_speed_entity = self.coordinator.hass.states.get(switch_entity_id)
-        return low_speed_entity.state if low_speed_entity else False
+        return low_speed_entity.state == STATE_ON if low_speed_entity else False

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -107,7 +107,9 @@ class VerticalCover(TahomaGenericCover):
         """Move the cover to a specific position."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed")
+            await self.executor.async_execute_command(
+                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed"
+            )
         else:
             await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
 
@@ -118,7 +120,9 @@ class VerticalCover(TahomaGenericCover):
                 COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 0, "lowspeed"
             )
         else:
-            await self.executor.async_execute_command(self.select_command(*COMMANDS_OPEN))
+            await self.executor.async_execute_command(
+                self.select_command(*COMMANDS_OPEN)
+            )
 
     async def async_close_cover(self, **_):
         """Close the cover."""
@@ -127,7 +131,9 @@ class VerticalCover(TahomaGenericCover):
                 COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 100, "lowspeed"
             )
         else:
-            await self.executor.async_execute_command(self.select_command(*COMMANDS_CLOSE))
+            await self.executor.async_execute_command(
+                self.select_command(*COMMANDS_CLOSE)
+            )
 
     def is_low_speed_enabled(self):
         """Return if low speed mode is enabled."""

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -14,7 +14,7 @@ from homeassistant.components.cover import (
     SUPPORT_STOP,
 )
 
-from .tahoma_cover import COMMANDS_STOP, TahomaGenericCover
+from .tahoma_cover import COMMANDS_STOP, SUPPORT_COVER_POSITION_LOW_SPEED, TahomaGenericCover
 
 COMMAND_CYCLE = "cycle"
 COMMAND_CLOSE = "close"
@@ -101,16 +101,27 @@ class VerticalCover(TahomaGenericCover):
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
-        await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
+        if self.is_low_speed_enabled():
+            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, position)
+        else:
+            await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
 
     async def async_open_cover(self, **_):
         """Open the cover."""
-        await self.executor.async_execute_command(
-            self.executor.select_command(*COMMANDS_OPEN)
-        )
+        if self.is_low_speed_enabled():
+            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, 0)
+        else:
+            await self.executor.async_execute_command(self.select_command(*COMMANDS_OPEN))
 
     async def async_close_cover(self, **_):
         """Close the cover."""
-        await self.executor.async_execute_command(
-            self.executor.select_command(*COMMANDS_CLOSE)
-        )
+        if self.is_low_speed_enabled():
+            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, 100)
+        else:
+            await self.executor.async_execute_command(self.select_command(*COMMANDS_CLOSE))
+
+    def is_low_speed_enabled(self):
+        """Return if low speed mode is enabled."""
+        switch_entity_id = f"{self.entity_id.replace('cover', 'switch')}_low_speed"
+        low_speed_entity = self.coordinator.hass.states.get(switch_entity_id)
+        return low_speed_entity.state if low_speed_entity else False

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -105,20 +105,16 @@ class VerticalCover(TahomaGenericCover):
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        position = 100 - kwargs.get(ATTR_POSITION, 0)
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(
-                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed"
-            )
+            await self.async_set_cover_position_low_speed(**kwargs)
         else:
+            position = 100 - kwargs.get(ATTR_POSITION, 0)
             await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
 
     async def async_open_cover(self, **_):
         """Open the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(
-                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 0, "lowspeed"
-            )
+            await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 100})
         else:
             await self.executor.async_execute_command(
                 self.executor.select_command(*COMMANDS_OPEN)
@@ -127,9 +123,7 @@ class VerticalCover(TahomaGenericCover):
     async def async_close_cover(self, **_):
         """Close the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(
-                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 100, "lowspeed"
-            )
+            await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 0})
         else:
             await self.executor.async_execute_command(
                 self.executor.select_command(*COMMANDS_CLOSE)
@@ -139,7 +133,7 @@ class VerticalCover(TahomaGenericCover):
         """Return if low speed mode is enabled."""
         if not self.executor.has_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED):
             return False
-        
+
         switch_entity_id = f"{self.entity_id.replace('cover', 'switch')}_low_speed"
         low_speed_entity = self.coordinator.hass.states.get(switch_entity_id)
         return low_speed_entity.state == STATE_ON if low_speed_entity else False

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -106,21 +106,25 @@ class VerticalCover(TahomaGenericCover):
         """Move the cover to a specific position."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position)
+            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed")
         else:
             await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
 
     async def async_open_cover(self, **_):
         """Open the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 0)
+            await self.executor.async_execute_command(
+                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 0, "lowspeed"
+            )
         else:
             await self.executor.async_execute_command(self.select_command(*COMMANDS_OPEN))
 
     async def async_close_cover(self, **_):
         """Close the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 100)
+            await self.executor.async_execute_command(
+                COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 100, "lowspeed"
+            )
         else:
             await self.executor.async_execute_command(self.select_command(*COMMANDS_CLOSE))
 

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -15,7 +15,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.const import STATE_ON
 
-from .tahoma.cover_devices.tahoma_cover import (
+from .tahoma_cover import (
     COMMAND_SET_CLOSURE_AND_LINEAR_SPEED,
     COMMANDS_STOP,
     TahomaGenericCover,
@@ -121,7 +121,7 @@ class VerticalCover(TahomaGenericCover):
             )
         else:
             await self.executor.async_execute_command(
-                self.select_command(*COMMANDS_OPEN)
+                self.executor.select_command(*COMMANDS_OPEN)
             )
 
     async def async_close_cover(self, **_):
@@ -132,7 +132,7 @@ class VerticalCover(TahomaGenericCover):
             )
         else:
             await self.executor.async_execute_command(
-                self.select_command(*COMMANDS_CLOSE)
+                self.executor.select_command(*COMMANDS_CLOSE)
             )
 
     def is_low_speed_enabled(self):

--- a/custom_components/tahoma/cover_devices/vertical_cover.py
+++ b/custom_components/tahoma/cover_devices/vertical_cover.py
@@ -14,7 +14,11 @@ from homeassistant.components.cover import (
     SUPPORT_STOP,
 )
 
-from .tahoma_cover import COMMANDS_STOP, SUPPORT_COVER_POSITION_LOW_SPEED, TahomaGenericCover
+from .tahoma.cover_devices.tahoma_cover import (
+    COMMAND_SET_CLOSURE_AND_LINEAR_SPEED,
+    COMMANDS_STOP,
+    TahomaGenericCover,
+)
 
 COMMAND_CYCLE = "cycle"
 COMMAND_CLOSE = "close"
@@ -102,21 +106,21 @@ class VerticalCover(TahomaGenericCover):
         """Move the cover to a specific position."""
         position = 100 - kwargs.get(ATTR_POSITION, 0)
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, position)
+            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, position)
         else:
             await self.executor.async_execute_command(COMMAND_SET_CLOSURE, position)
 
     async def async_open_cover(self, **_):
         """Open the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, 0)
+            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 0)
         else:
             await self.executor.async_execute_command(self.select_command(*COMMANDS_OPEN))
 
     async def async_close_cover(self, **_):
         """Close the cover."""
         if self.is_low_speed_enabled():
-            await self.executor.async_execute_command(SUPPORT_COVER_POSITION_LOW_SPEED, 100)
+            await self.executor.async_execute_command(COMMAND_SET_CLOSURE_AND_LINEAR_SPEED, 100)
         else:
             await self.executor.async_execute_command(self.select_command(*COMMANDS_CLOSE))
 

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
         [
             TahomaLowSpeedSwitch(device.deviceurl, coordinator)
             for device in data["platforms"].get(COVER)
-            if COMMAND_SET_CLOSURE_AND_LINEAR_SPEED not in device.definition.commands
+            if COMMAND_SET_CLOSURE_AND_LINEAR_SPEED in device.definition.commands
         ]
     )
 

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -144,8 +144,6 @@ class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
     def __init__(self, device_url: str, coordinator: TahomaDataUpdateCoordinator):
         """Initialize the low speed switch."""
         super().__init__(device_url, coordinator)
-        self._attr_name = f"{super().name} low speed"
-        self._attr_assumed_state = True
         self._is_on = False
 
     async def async_added_to_hass(self):
@@ -154,6 +152,16 @@ class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
         state = await self.async_get_last_state()
         if state:
             self._is_on = state.state == STATE_ON
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return f"{super().name} low speed"
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return True if unable to access real state of the entity."""
+        return True
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
 
     entities.extend(
         [
-            TahomaLowSpeedSwitch(device.deviceurl, coordinator)
+            TahomaLowSpeedCoverSwitch(device.deviceurl, coordinator)
             for device in data["platforms"].get(COVER)
             if COMMAND_SET_CLOSURE_AND_LINEAR_SPEED in device.definition.commands
         ]
@@ -136,7 +136,7 @@ class TahomaSwitch(OverkizEntity, SwitchEntity):
         )
 
 
-class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
+class TahomaLowSpeedCoverSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
     """Representation of Low Speed Switch."""
 
     _attr_icon = "mdi:feather"

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -1,7 +1,8 @@
 """Support for TaHoma switches."""
 import logging
-from typing import Optional
+from typing import Any, Optional
 
+from homeassistant.components.cover import DOMAIN as COVER
 from homeassistant.components.switch import (
     DEVICE_CLASS_SWITCH,
     DOMAIN as SWITCH,
@@ -11,6 +12,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from custom_components.tahoma.coordinator import TahomaDataUpdateCoordinator
+from custom_components.tahoma.cover_devices.tahoma_cover import (
+    COMMAND_SET_CLOSURE_AND_LINEAR_SPEED,
+)
 
 from .const import COMMAND_OFF, COMMAND_ON, CORE_ON_OFF_STATE, DOMAIN
 from .entity import OverkizEntity
@@ -44,6 +51,14 @@ async def async_setup_entry(
         TahomaSwitch(device.deviceurl, coordinator)
         for device in data["platforms"][SWITCH]
     ]
+
+    entities.extend(
+        [
+            TahomaLowSpeedSwitch(device.deviceurl, coordinator)
+            for device in data["platforms"].get(COVER)
+            if COMMAND_SET_CLOSURE_AND_LINEAR_SPEED not in device.definition.commands
+        ]
+    )
 
     async_add_entities(entities)
 
@@ -119,3 +134,38 @@ class TahomaSwitch(OverkizEntity, SwitchEntity):
             self.executor.select_state(CORE_ON_OFF_STATE, IO_FORCE_HEATING_STATE)
             == STATE_ON
         )
+
+
+class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
+    """Representation of Low Speed Switch."""
+
+    _attr_icon = "mdi:feather"
+
+    def __init__(self, device_url: str, coordinator: TahomaDataUpdateCoordinator):
+        """Initialize the low speed switch."""
+        super().__init__(device_url, coordinator)
+        self._attr_name = f"{super().name} low speed"
+        self.attr_assumed_state = True
+        self._is_on = False
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+            self._is_on = state.state == STATE_ON
+
+    @property
+    def is_on(self) -> bool:
+        """Get whether the switch is in on state."""
+        return self._is_on
+
+    def async_turn_on(self, **kwargs: Any) -> None:
+        """Send the on command."""
+        self._is_on = True
+        self.async_write_ha_state()
+
+    def async_turn_off(self, **kwargs: Any) -> None:
+        """Send the off command."""
+        self._is_on = False
+        self.async_write_ha_state()

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -168,12 +168,12 @@ class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
         """Get whether the switch is in on state."""
         return self._is_on
 
-    def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the on command."""
         self._is_on = True
         self.async_write_ha_state()
 
-    def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the off command."""
         self._is_on = False
         self.async_write_ha_state()

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -159,11 +159,6 @@ class TahomaLowSpeedCoverSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
         return f"{super().name} low speed"
 
     @property
-    def assumed_state(self) -> bool:
-        """Return True if unable to access real state of the entity."""
-        return True
-
-    @property
     def is_on(self) -> bool:
         """Get whether the switch is in on state."""
         return self._is_on

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -145,7 +145,7 @@ class TahomaLowSpeedSwitch(OverkizEntity, SwitchEntity, RestoreEntity):
         """Initialize the low speed switch."""
         super().__init__(device_url, coordinator)
         self._attr_name = f"{super().name} low speed"
-        self.attr_assumed_state = True
+        self._attr_assumed_state = True
         self._is_on = False
 
     async def async_added_to_hass(self):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8216238/127117337-cda749a7-4b37-40b5-94a7-70400f68d396.png)


![image](https://user-images.githubusercontent.com/8216238/127117181-a678ac0c-b39f-4f33-a29a-402e21102cc5.png)

*Discret* is the french word for low mode

Instead of a service, I suggest to use an entity switch as device option. So no need anymore to create cover template.

For the icon, I choose the same one used by the Somfy switch: https://www.somfy.fr/produits/1033114/s-so-rs100-io