### PR TITLE
Bump version to 2.6.2

### DIFF
--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -14,5 +14,5 @@
     "@tetienne"
   ],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues",
-  "version": "2.4.10"
+  "version": "2.6.2"
 }


### PR DESCRIPTION
Apparently we missed the version key in manifest.json. Now at least I know why the analytics weren't correct..