### PR TITLE
Rebrand integration name to Overkiz (by Somfy) and change descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Custom component for Home Assistant to interact with smart devices via the Overk
 ## Supported hubs
 
 - Somfy TaHoma
-- Somfy Tahoma Switch
+- Somfy TaHoma Switch
 - Somfy Connexoon IO
 - Somfy Connexoon RTS
-- Cozytouch
-- Hi Kumo
-- Rexel
-- eedomus
+- Atlantic Cozytouch
+- Hitachi Hi Kumo
+- Rexel Energeasy Connect
+- Nexity Eugénie
 
 ## Supported devices
 
@@ -32,7 +32,7 @@ Copy the `custom_components/tahoma` to your `custom_components` folder. Reboot H
 
 ### HACS
 
-This integration is included in HACS. Search for the `Somfy TaHoma` integration and choose install. Reboot Home Assistant and install the Somfy TaHoma integration via the integrations page or press the blue button below.
+This integration is included in HACS. Search for the `Overkiz (by Somfy)` integration and choose install. Reboot Home Assistant and install the Somfy TaHoma integration via the integrations page or press the blue button below.
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=tahoma)
 
@@ -42,10 +42,10 @@ This integration is included in HACS. Search for the `Somfy TaHoma` integration 
 
 After installation this integration adds new services to Home Assistant which can be used in automations. The new services are:
 
-+ Somfy TaHoma: Set cover position with low speed (tahoma.set_cover_position_low_speed, only added if supported by the device)
-+ Somfy TaHoma: My position (cover) (tahoma.set_cover_my_position)
-+ Somfy TaHoma: Execute command (tahoma.execute_command)
-+ Somfy TaHoma: Get execution history (tahoma.get_execution_history)
++ Overkiz (by Somfy): Set cover position with low speed (tahoma.set_cover_position_low_speed, only added if supported by the device)
++ Overkiz (by Somfy): My position (cover) (tahoma.set_cover_my_position)
++ Overkiz (by Somfy): Execute command (tahoma.execute_command)
++ Overkiz (by Somfy): Get execution history (tahoma.get_execution_history)
 
 If you want to move your covers always with low speed create [templates](https://www.home-assistant.io/integrations/cover.template/) for each cover which calls the first service.
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,20 @@ This integration doesn't rely on a hardcoded list of devices anymore, but relies
 
 ## Installation
 
-### Manual
-
-Copy the `custom_components/tahoma` to your `custom_components` folder. Reboot Home Assistant and install the Somfy TaHoma integration via the integrations page or press the blue button below.
+You can install this integration via [HACS](#hacs) or [manually](#manual).
 
 ### HACS
 
-This integration is included in HACS. Search for the `Overkiz (by Somfy)` integration and choose install. Reboot Home Assistant and install the Somfy TaHoma integration via the integrations page or press the blue button below.
+This integration is included in HACS. Search for the `Overkiz (by Somfy)` integration and choose install. Reboot Home Assistant and configure the 'Overkiz (by Somfy)' integration via the integrations page or press the blue button below.
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=tahoma)
+
+### Manual
+
+Copy the `custom_components/tahoma` to your `custom_components` folder. Reboot Home Assistant and configure the 'Overkiz (by Somfy)' integration via the integrations page or press the blue button below.
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=tahoma)
+
 
 ## Advanced
 

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tahoma",
-  "name": "Somfy TaHoma",
+  "name": "Overkiz (by Somfy)",
   "iot_class": "cloud_polling",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
@@ -14,5 +14,11 @@
     "@tetienne"
   ],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues",
-  "version": "2.4.10"
+  "version": "2.4.10",
+  "dhcp": [
+    {
+      "hostname": "gateway*",
+      "macaddress": "F8811A*"
+    }
+  ]
 }

--- a/custom_components/tahoma/strings.json
+++ b/custom_components/tahoma/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
+        "description": "The Overkiz platform is used by various vendors like Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) and Atlantic (Cozytouch). Enter your application credentials and select your hub.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
@@ -25,7 +25,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
+        "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
+        "description": "The Overkiz platform is used by various vendors like Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) and Atlantic (Cozytouch). Enter your application credentials and select your hub.",
         "data": {
           "username": "Email address",
           "password": "Password",
@@ -25,7 +25,7 @@
     "step": {
       "update_interval": {
         "title": "Update Interval",
-        "description": "The Somfy TaHoma integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
+        "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
         "data": {
           "update_interval": "Update interval (in seconds)"
         }

--- a/custom_components/tahoma/translations/fr.json
+++ b/custom_components/tahoma/translations/fr.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Entrez vos identifiants TaHoma.",
+        "description": "La platform Overkiz est utilisée par différents fournisseurs comme Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) et Atlantic (Cozytouch). Entrez les informations d'identification de votre application et sélectionnez votre hub.",
         "data": {
           "username": "Courriel",
           "password": "Mot de passe",
@@ -25,7 +25,7 @@
     "step": {
       "update_interval": {
         "title": "Intervalle de mise à jour",
-        "description": "L'intégration Somfy TaHoma récupère régulièrement de nouveaux évènements. Modifiez l'intervalle de mise à jour par une valeur inférieure si vous souhaitez des mises à jour plus fréquentes, par exemple quand vous contrôllez aussi vos appareils en dehors de Home Assistant.",
+        "description": "L'intégration Overkiz récupère régulièrement de nouveaux évènements. Modifiez l'intervalle de mise à jour par une valeur inférieure si vous souhaitez des mises à jour plus fréquentes, par exemple quand vous contrôllez aussi vos appareils en dehors de Home Assistant.",
         "data": {
           "update_interval": "Intervalle de mise à jour (en secondes)"
         }

--- a/custom_components/tahoma/translations/nl.json
+++ b/custom_components/tahoma/translations/nl.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Voer uw TaHoma inloggegevens in voor de TaHoma-app of het tahomalink.com platform.",
+        "description": "Het Overkiz platform wordt gebruikt door fabrikanten zoals Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) en Atlantic (Cozytouch). Voer uw inloggegevens in en selecteer je hub.",
         "data": {
           "username": "E-mailadres",
           "password": "Wachtwoord",
@@ -25,7 +25,7 @@
     "step": {
       "update_interval": {
         "title": "Update interval",
-        "description": "De Somfy TaHoma-integratie haalt periodiek nieuwe gebeurtenissen op. Wijzig de update-interval naar een lagere waarde als je vaker updates wilt, bijvoorbeeld wanneer je je apparaten ook buiten Home Assistant bedient.",
+        "description": "De Overkiz integratie haalt periodiek nieuwe gebeurtenissen op. Wijzig de update-interval naar een lagere waarde als je vaker updates wilt, bijvoorbeeld wanneer je je apparaten ook buiten Home Assistant bedient.",
         "data": {
           "update_interval": "Update interval (in seconden)"
         }

--- a/custom_components/tahoma/translations/nl.json
+++ b/custom_components/tahoma/translations/nl.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Het Overkiz platform wordt gebruikt door fabrikanten zoals Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) en Atlantic (Cozytouch). Voer uw inloggegevens in en selecteer je hub.",
+        "description": "Het Overkiz platform wordt gebruikt door fabrikanten zoals Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) en Atlantic (Cozytouch). Voer je inloggegevens in en selecteer je hub.",
         "data": {
           "username": "E-mailadres",
           "password": "Wachtwoord",


### PR DESCRIPTION
Let's try to keep it as close to our core PR as possible, but with the `tahoma` domain to not cause any breaking changes.