### PR TITLE
Add sensor for Discrete RSSI Level (disabled by default)

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -307,6 +307,13 @@ SENSOR_DESCRIPTIONS = [
         icon="mdi:content-save-cog",
         entity_registry_enabled_default=False,
     ),
+    OverkizSensorDescription(
+        key="core:DiscreteRSSILevelState",
+        name="Discrete RSSI Level",
+        entity_registry_enabled_default=False,
+        native_value=lambda value: str(value).capitalize(),
+        device_class=sensor.DEVICE_CLASS_SIGNAL_STRENGTH,
+    ),
 ]
 
 


### PR DESCRIPTION
Based on feedback on the community forum, disabled by default since I don't see the value for all users.

<img width="502" alt="Screen Shot 2021-08-19 at 16 41 21" src="https://user-images.githubusercontent.com/1424596/130097185-2431cd38-dccc-40ac-915d-7389fb7b73e7.png">
