### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from homeassistant.components import sensor
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
@@ -18,7 +22,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.dt import utc_from_timestamp
 
 from .const import DOMAIN
 from .entity import OverkizDescriptiveEntity, OverkizSensorDescription
@@ -126,8 +129,7 @@ SENSOR_DESCRIPTIONS = [
         name="Electric Energy Consumption",
         device_class=sensor.DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_WATT_HOUR,  # core:MeasuredValueType = core:ElectricalEnergyInWh (not for modbus:YutakiV2DHWElectricalEnergyConsumptionComponent)
-        state_class=STATE_CLASS_MEASUREMENT,  # core:MeasurementCategory attribute = electric/overall
-        last_reset=utc_from_timestamp(0),
+        state_class=STATE_CLASS_TOTAL_INCREASING,  # core:MeasurementCategory attribute = electric/overall
     ),
     OverkizSensorDescription(
         key="core:ElectricPowerConsumptionState",

--- a/hacs.json
+++ b/hacs.json
@@ -11,7 +11,7 @@
     "switch",
     "water_heater"
   ],
-  "homeassistant": "2021.8.0",
+  "homeassistant": "2021.9.0",
   "render_readme": "true",
   "iot_class": "Cloud Polling"
 }


### PR DESCRIPTION
See https://developers.home-assistant.io/blog/2021/08/16/state_class_total

> A new state class, total_increasing has been added. In addition, the last_reset attribute is removed from SensorEntity. The driver for the changes is to make it easier to integrate with devices, like utility meters.

Fix #548