### PR TITLE
Fix NoneType object is not iterable when there is no cover

### DIFF
--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     entities.extend(
         [
             OverkizLowSpeedCoverSwitch(device.deviceurl, coordinator)
-            for device in data["platforms"].get(COVER)
+            for device in data["platforms"][COVER]
             if COMMAND_SET_CLOSURE_AND_LINEAR_SPEED in device.definition.commands
         ]
     )


### PR DESCRIPTION
Fix #554

The get method bypass the defaultdict behavior. 


![Capture d’écran 2021-09-08 à 08 44 44](https://user-images.githubusercontent.com/8216238/132460252-8d2c02a7-9c14-42b0-904d-b575711418e0.png)
![Capture d’écran 2021-09-08 à 08 44 04](https://user-images.githubusercontent.com/8216238/132460260-b03f74f1-d051-4361-9c21-ad1d4723b4b7.png)
