### PR TITLE
Remove polling custom interval and reduce it for stateless configuration

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -1,7 +1,6 @@
 """The Overkiz (by Somfy) integration."""
 import asyncio
 from collections import defaultdict
-from datetime import datetime
 from enum import Enum
 import logging
 
@@ -38,6 +37,7 @@ from .const import (
     IGNORED_OVERKIZ_DEVICES,
     OVERKIZ_DEVICE_TO_PLATFORM,
     UPDATE_INTERVAL,
+    UPDATE_INTERVAL_ALL_ASSUMED_STATE,
 )
 from .coordinator import OverkizDataUpdateCoordinator
 
@@ -167,7 +167,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         config_entry_id=entry.entry_id,
     )
 
-    await coordinator.async_refresh()
+    await coordinator.async_config_entry_first_refresh()
+
+    if coordinator.is_stateless:
+        _LOGGER.debug(
+            "All devices have assumed state. Update interval has been reduced to: %s",
+            UPDATE_INTERVAL_ALL_ASSUMED_STATE,
+        )
+        coordinator.update_interval = UPDATE_INTERVAL_ALL_ASSUMED_STATE
 
     platforms = defaultdict(list)
     platforms[SCENE] = scenarios

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -8,9 +8,8 @@ from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.components.dhcp import HOSTNAME
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import device_registry as dr
 from pyhoma.client import TahomaClient
 from pyhoma.const import SUPPORTED_SERVERS
 from pyhoma.exceptions import (
@@ -21,13 +20,7 @@ from pyhoma.exceptions import (
 from pyhoma.models import obfuscate_id
 import voluptuous as vol
 
-from .const import (
-    CONF_HUB,
-    CONF_UPDATE_INTERVAL,
-    DEFAULT_HUB,
-    DEFAULT_UPDATE_INTERVAL,
-    MIN_UPDATE_INTERVAL,
-)
+from .const import CONF_HUB, DEFAULT_HUB
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,12 +30,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Somfy TaHoma."""
 
     VERSION = 2
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Handle the flow."""
-        return OptionsFlowHandler(config_entry)
 
     def __init__(self) -> None:
         """Start the Overkiz config flow."""
@@ -178,35 +165,4 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_registry.async_get_device(
                 identifiers={(DOMAIN, gateway_id)}, connections=set()
             )
-        )
-
-
-class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle a option flow for Somfy TaHoma."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the Somfy TaHoma options."""
-        return await self.async_step_update_interval()
-
-    async def async_step_update_interval(self, user_input=None):
-        """Manage the options regarding interval updates."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        return self.async_show_form(
-            step_id="update_interval",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_UPDATE_INTERVAL,
-                        default=self.config_entry.options.get(
-                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                        ),
-                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
-                }
-            ),
         )

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -1,4 +1,6 @@
 """Constants for the Overkiz (by Somfy) integration."""
+from datetime import timedelta
+
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_CONTROL_PANEL
 from homeassistant.components.climate import DOMAIN as CLIMATE
 from homeassistant.components.cover import DOMAIN as COVER
@@ -12,8 +14,7 @@ DOMAIN = "tahoma"
 CONF_HUB = "hub"
 DEFAULT_HUB = "somfy_europe"
 
-MIN_UPDATE_INTERVAL = 30
-DEFAULT_UPDATE_INTERVAL = 30
+UPDATE_INTERVAL = timedelta(seconds=30)
 
 IGNORED_OVERKIZ_DEVICES = [
     "ProtocolGateway",
@@ -90,5 +91,3 @@ CORE_ON_OFF_STATE = "core:OnOffState"
 
 COMMAND_OFF = "off"
 COMMAND_ON = "on"
-
-CONF_UPDATE_INTERVAL = "update_interval"

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -15,6 +15,7 @@ CONF_HUB = "hub"
 DEFAULT_HUB = "somfy_europe"
 
 UPDATE_INTERVAL = timedelta(seconds=30)
+UPDATE_INTERVAL_ALL_ASSUMED_STATE = timedelta(minutes=60)
 
 IGNORED_OVERKIZ_DEVICES = [
     "ProtocolGateway",

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -61,6 +61,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         self.data = {}
         self.client = client
         self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
+        self.is_stateless = all(len(device.states) == 0 for device in devices)
         self.executions: Dict[str, Dict[str, str]] = {}
         self.areas = self.places_to_area(places)
         self._config_entry_id = config_entry_id
@@ -135,7 +136,8 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
                 if event.exec_id not in self.executions:
                     self.executions[event.exec_id] = {}
 
-                self.update_interval = timedelta(seconds=1)
+                if not self.is_stateless:
+                    self.update_interval = timedelta(seconds=1)
 
             elif (
                 event.name == EventName.EXECUTION_STATE_CHANGED

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -19,7 +19,7 @@ from pyhoma.exceptions import (
 )
 from pyhoma.models import DataType, Device, Place, State
 
-from .const import DOMAIN
+from .const import DOMAIN, UPDATE_INTERVAL
 
 TYPES = {
     DataType.NONE: None,
@@ -59,7 +59,6 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
         self.data = {}
-        self.original_update_interval = update_interval
         self.client = client
         self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
         self.executions: Dict[str, Dict[str, str]] = {}
@@ -146,7 +145,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
                 del self.executions[event.exec_id]
 
         if not self.executions:
-            self.update_interval = self.original_update_interval
+            self.update_interval = UPDATE_INTERVAL
 
         return self.devices
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -61,7 +61,11 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         self.data = {}
         self.client = client
         self.devices: Dict[str, Device] = {d.deviceurl: d for d in devices}
-        self.is_stateless = all(len(device.states) == 0 for device in devices)
+        self.is_stateless = all(
+            device.deviceurl.startswith("rts://")
+            or device.deviceurl.startswith("internal://")
+            for device in devices
+        )
         self.executions: Dict[str, Dict[str, str]] = {}
         self.areas = self.places_to_area(places)
         self._config_entry_id = config_entry_id

--- a/custom_components/tahoma/strings.json
+++ b/custom_components/tahoma/strings.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Update Interval",
-        "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
-        "data": {
-          "update_interval": "Update interval (in seconds)"
-        }
-      }
-    }
   }
 }

--- a/custom_components/tahoma/translations/de.json
+++ b/custom_components/tahoma/translations/de.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "Der Account ist bereits eingerichtet."
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Update Intervall",
-        "description": "Die Somfy TaHoma Integration erhält periodisch neue Ereignisse (Events). Wenn deine Geräte auch außerhalb von Home Assistant gesteuert werden, kann es Sinn machen das Update Intervall zu verkürzen, um öfter Updates zu bekommen.",
-        "data": {
-          "update_interval": "Update Intervall (in Sekunden)"
-        }
-      }
-    }
   }
 }

--- a/custom_components/tahoma/translations/en.json
+++ b/custom_components/tahoma/translations/en.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "Account is already configured"
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Update Interval",
-        "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
-        "data": {
-          "update_interval": "Update interval (in seconds)"
-        }
-      }
-    }
   }
 }

--- a/custom_components/tahoma/translations/fr.json
+++ b/custom_components/tahoma/translations/fr.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "Votre compte a déjà été ajouté pour cette intégration."
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Intervalle de mise à jour",
-        "description": "L'intégration Overkiz récupère régulièrement de nouveaux évènements. Modifiez l'intervalle de mise à jour par une valeur inférieure si vous souhaitez des mises à jour plus fréquentes, par exemple quand vous contrôllez aussi vos appareils en dehors de Home Assistant.",
-        "data": {
-          "update_interval": "Intervalle de mise à jour (en secondes)"
-        }
-      }
-    }
   }
 }

--- a/custom_components/tahoma/translations/nl.json
+++ b/custom_components/tahoma/translations/nl.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "Account is al geconfigureerd"
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Update interval",
-        "description": "De Overkiz integratie haalt periodiek nieuwe gebeurtenissen op. Wijzig de update-interval naar een lagere waarde als je vaker updates wilt, bijvoorbeeld wanneer je je apparaten ook buiten Home Assistant bedient.",
-        "data": {
-          "update_interval": "Update interval (in seconden)"
-        }
-      }
-    }
   }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -240,44 +240,6 @@ async def test_import_failing(hass, side_effect, error, enable_custom_integratio
     # Should write Exception to the log
 
 
-async def test_options_flow(hass, enable_custom_integrations):
-    """Test options flow."""
-
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN,
-        unique_id=TEST_EMAIL,
-        data={"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
-        version=2,
-    )
-
-    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
-        "custom_components.tahoma.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert len(hass.config_entries.async_entries(config_flow.DOMAIN)) == 1
-    assert entry.state == config_entries.ConfigEntryState.LOADED
-
-    result = await hass.config_entries.options.async_init(
-        entry.entry_id, context={"source": "test"}, data=None
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "update_interval"
-
-    assert entry.options == {}
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "update_interval": 12000,
-        },
-    )
-
-    assert entry.options == {"update_interval": 12000}
-
-
 async def test_dhcp_flow(hass):
     """Test that DHCP discovery for new bridge works."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
To integrate Home Assistant Core, we must remove this feature. This one will be refused by the Core team. 