### PR TITLE
Trigger event on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,31 @@ After installation this integration adds new services to Home Assistant which ca
 + Overkiz (by Somfy): Execute command (tahoma.execute_command)
 + Overkiz (by Somfy): Get execution history (tahoma.get_execution_history)
 
+## Events
+This component listen for events returned by Overkiz. In case of command failure, the event will forwarded to Home Assistant.
+
+You can subscribe to the `overkiz.event` event type in Developer Tools/Events in order to examine the event data JSON for the correct parameters to use in your automations. For example, `overkiz.event` returns event data JSON similar to the following when your cover is blocked.
+
+```JSON
+{
+    "event_type": "overkiz.event",
+    "data": {
+        "event_name": "ExecutionStateChangedEvent",
+        "failure_type_code": 106,
+        "failure_type": "CMDCANCELLED"
+    },
+    "origin": "LOCAL",
+    "time_fired": "2021-09-28T20:03:57.102478+00:00",
+    "context": {
+        "id": "92a84240d914b43ceaf1aee3249568f6",
+        "parent_id": null,
+        "user_id": null
+    }
+}
+```
+
+You can find the list of available failure_type [here](https://github.com/iMicknl/python-tahoma-api/blob/master/pyhoma/enums.py#L118).
+
 ### Enable debug logging
 
 The [logger](https://www.home-assistant.io/integrations/logger/) integration lets you define the level of logging activities in Home Assistant. Turning on debug mode will show more information about unsupported devices in your logbook.

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -98,6 +98,22 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         for event in events:
             _LOGGER.debug(event)
 
+            if event.failure_type_code:
+                # Some event names are not mapped to an enum, it’s why this trick.
+                # Like CommandExecutionStateChangedEvent
+                try:
+                    raw_event_name = event.name.value
+                except AttributeError:
+                    raw_event_name = event.name
+
+                self.hass.bus.fire(
+                    raw_event_name,
+                    {
+                        "failure_type_code": event.failure_type_code.value,
+                        "failure_type": event.failure_type,
+                    },
+                )
+
             if event.name == EventName.DEVICE_AVAILABLE:
                 self.devices[event.deviceurl].available = True
 

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -99,12 +99,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(event)
 
             if event.failure_type_code:
-                # Some event names are not mapped to an enum, it’s why this trick.
-                # Like CommandExecutionStateChangedEvent
-                try:
-                    raw_event_name = event.name.value
-                except AttributeError:
-                    raw_event_name = event.name
+                raw_event_name = event.name.value
 
                 self.hass.bus.fire(
                     raw_event_name,

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -99,11 +99,10 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(event)
 
             if event.failure_type_code:
-                raw_event_name = event.name.value
-
                 self.hass.bus.fire(
-                    raw_event_name,
+                    "overkiz.event",
                     {
+                        "event_name": event.name.value,
                         "failure_type_code": event.failure_type_code.value,
                         "failure_type": event.failure_type,
                     },


### PR DESCRIPTION
Some events are not persisted though states. For this reason, and to allow automation, we can fire our own event. 

```JSON
{
    "event_type": "overkiz.event",
    "data": {
        "event_name": "ExecutionStateChangedEvent",
        "failure_type_code": 106,
        "failure_type": "CMDCANCELLED"
    },
    "origin": "LOCAL",
    "time_fired": "2021-09-28T20:03:57.102478+00:00",
    "context": {
        "id": "92a84240d914b43ceaf1aee3249568f6",
        "parent_id": null,
        "user_id": null
    }
}
```

TODO:
- [x] documentation