### PR TITLE
Add HomeKit Setup Code sensor (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ In order to gather more information, you can use the `tahoma.get_execution_histo
 
 ### Retrieve HomeKit code
 
-If your TaHoma box supports HomeKit natively, the integration will log the HomeKit code on start currently. This is currently an experimental implementation and in order to enable this, you need to have debug logging enabled.
+If your hub (e.g. Somfy TaHoma) supports HomeKit natively, your setup code will be added as a sensor in Home Assistant. Look up your hub in Home Assistant and retrieve the value from the 'HomeKit Setup Code' sensor. You can now setup the [HomeKit Controller](https://www.home-assistant.io/integrations/homekit_controller/) integration in Home Assistant.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ In order to gather more information, you can use the `tahoma.get_execution_histo
 
 ### Retrieve HomeKit code
 
-If your hub (e.g. Somfy TaHoma) supports HomeKit natively, your setup code will be added as a sensor in Home Assistant. Look up your hub in Home Assistant and retrieve the value from the 'HomeKit Setup Code' sensor. You can now setup the [HomeKit Controller](https://www.home-assistant.io/integrations/homekit_controller/) integration in Home Assistant.
+If your hub (e.g. Somfy TaHoma) supports HomeKit natively, your setup code will be added as a sensor in Home Assistant. Look up your hub in Home Assistant and retrieve the value from the 'HomeKit Setup Code' sensor. You can now configure the [HomeKit Controller](https://www.home-assistant.io/integrations/homekit_controller/) integration in Home Assistant.

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -46,9 +46,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_EXECUTE_COMMAND = "execute_command"
 
-HOMEKIT_SETUP_CODE = "homekit:SetupCode"
-HOMEKIT_STACK = "HomekitStack"
-
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
@@ -204,9 +201,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ):
             log_device("Unsupported device detected", device)
 
-        if device.widget == HOMEKIT_STACK:
-            print_homekit_setup_code(device)
-
     supported_platforms = set(platforms.keys())
 
     # Sensor and Binary Sensor will be added dynamically, based on the device states
@@ -323,15 +317,6 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
         coordinator.original_update_interval = new_update_interval
 
         await coordinator.async_refresh()
-
-
-def print_homekit_setup_code(device: Device):
-    """Retrieve and print HomeKit Setup Code."""
-    if device.attributes:
-        homekit = device.attributes.get(HOMEKIT_SETUP_CODE)
-
-        if homekit:
-            _LOGGER.info("HomeKit support detected with setup code %s.", homekit.value)
 
 
 async def write_execution_history_to_log(client: TahomaClient):

--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -385,7 +385,6 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
         """Initialize the device."""
         super().__init__(device_url, coordinator)
         self._attr_name = "HomeKit Setup Code"
-        self._attr_entity_registry_enabled_default = False
         self._attr_icon = "mdi:shield-home"
 
     @property
@@ -396,8 +395,8 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device registry information for this entity."""
-        # By default HomeKit devices will be listed at a virtual HomekitStack device,
-        # but it makes more sense to show this at the gateway in the entity registry.
+        # By default this sensor will be listed at a virtual HomekitStack device,
+        # but it makes more sense to show this at the gateway device in the entity registry.
         return {
             "identifiers": {(DOMAIN, self.executor.get_gateway_id())},
         }

--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -1,6 +1,8 @@
 """Support for Overkiz sensors."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components import sensor
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
@@ -24,7 +26,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import OverkizDescriptiveEntity, OverkizSensorDescription
+from .coordinator import OverkizDataUpdateCoordinator
+from .entity import OverkizDescriptiveEntity, OverkizEntity, OverkizSensorDescription
+
+HOMEKIT_SETUP_CODE = "homekit:SetupCode"
+HOMEKIT_STACK = "HomekitStack"
 
 SENSOR_DESCRIPTIONS = [
     OverkizSensorDescription(
@@ -336,6 +342,14 @@ async def async_setup_entry(
                     )
                 )
 
+        if device.widget == HOMEKIT_STACK:
+            entities.append(
+                OverkizHomeKitSetupCodeSensor(
+                    device.deviceurl,
+                    coordinator,
+                )
+            )
+
     async_add_entities(entities)
 
 
@@ -355,3 +369,28 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
             return self.entity_description.native_value(state.value)
 
         return state.value
+
+
+class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
+    """Representation of an Overkiz HomeKit Setup Code."""
+
+    def __init__(self, device_url: str, coordinator: OverkizDataUpdateCoordinator):
+        """Initialize the device."""
+        super().__init__(device_url, coordinator)
+        self._attr_name = "HomeKit Setup Code"
+        self._attr_entity_registry_enabled_default = False
+        self._attr_icon = "mdi:shield-home"
+
+    @property
+    def state(self):
+        """Return the value of the sensor."""
+        return self.device.attributes.get(HOMEKIT_SETUP_CODE).value
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+        # By default HomeKit devices will be listed at a virtual HomekitStack device,
+        # but it makes more sense to show this at the gateway in the entity registry.
+        return {
+            "identifiers": {(DOMAIN, self.executor.get_gateway_id())},
+        }


### PR DESCRIPTION
Fixes #579 

The only issue is that you need to reboot Home Assistant after you enabled the sensor, due to #560. I will add a screenshot as soon as my 'too many request' issue is solved...