### PR TITLE
Move overkiz.event to the end of the `coordinator` logic

### DIFF
--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -102,16 +102,6 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
         for event in events:
             _LOGGER.debug(event)
 
-            if event.failure_type_code:
-                self.hass.bus.fire(
-                    "overkiz.event",
-                    {
-                        "event_name": event.name.value,
-                        "failure_type_code": event.failure_type_code.value,
-                        "failure_type": event.failure_type,
-                    },
-                )
-
             if event.name == EventName.DEVICE_AVAILABLE:
                 self.devices[event.device_url].available = True
 
@@ -159,6 +149,17 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator):
                 and event.new_state in [ExecutionState.COMPLETED, ExecutionState.FAILED]
             ):
                 del self.executions[event.exec_id]
+
+            # Log errors via `overkiz_event`
+            if event.failure_type_code:
+                self.hass.bus.fire(
+                    "overkiz.event",
+                    {
+                        "event_name": event.name.value,
+                        "failure_type_code": event.failure_type_code.value,
+                        "failure_type": event.failure_type,
+                    },
+                )
 
         if not self.executions:
             self.update_interval = UPDATE_INTERVAL


### PR DESCRIPTION
@tetienne wouldn't it make sense to have this code at the end of our coordinator logic? This means that it won't interfere with our core functions at least.

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/638"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

