### PR TITLE
Fix number entity when state is None

### DIFF
--- a/custom_components/tahoma/number.py
+++ b/custom_components/tahoma/number.py
@@ -62,8 +62,8 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
     @property
     def value(self) -> float:
         """Return the current number."""
-        if self.device.states.get(self.entity_description.key):
-            return self.device.states.get(self.entity_description.key).value
+        if state := self.device.states.get(self.entity_description.key):
+            return state.value
 
         return None
 

--- a/custom_components/tahoma/number.py
+++ b/custom_components/tahoma/number.py
@@ -62,7 +62,10 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
     @property
     def value(self) -> float:
         """Return the current number."""
-        return self.device.states.get(self.entity_description.key).value
+        if self.device.states.get(self.entity_description.key):
+            return self.device.states.get(self.entity_description.key).value
+
+        return None
 
     async def async_set_value(self, value: float) -> None:
         """Update the My position value. Min: 0, max: 100."""

--- a/custom_components/tahoma/select.py
+++ b/custom_components/tahoma/select.py
@@ -59,7 +59,7 @@ class PedestrianGateSelect(OverkizEntity, SelectEntity):
     @property
     def current_option(self):
         """Return the selected entity option to represent the entity state."""
-        return self.device.states.get(CORE_OPEN_CLOSED_PEDESTRIAN_STATE).value
+        return self.device.states[CORE_OPEN_CLOSED_PEDESTRIAN_STATE].value
 
     @property
     def options(self):

--- a/custom_components/tahoma/select.py
+++ b/custom_components/tahoma/select.py
@@ -59,7 +59,7 @@ class PedestrianGateSelect(OverkizEntity, SelectEntity):
     @property
     def current_option(self):
         """Return the selected entity option to represent the entity state."""
-        return self.device.states[CORE_OPEN_CLOSED_PEDESTRIAN_STATE].value
+        return self.device.states.get(CORE_OPEN_CLOSED_PEDESTRIAN_STATE).value
 
     @property
     def options(self):


### PR DESCRIPTION
`core:Memorized1PositionState` isn't set, thus the state is not available. However, we create a number entity when they have the state definition available.  

This was the bug that @mstuij faced in https://github.com/iMicknl/ha-tahoma/issues/629#issuecomment-954811387. 

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/641"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

