### PR TITLE
Add support for ZeroConf discovery

### DIFF
--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -140,12 +140,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
+        """Handle ZeroConf discovery."""
+
         # abort if we already have exactly this bridge id/host
         # reload the integration if the host got updated
         properties = discovery_info.properties
         gateway_id = properties["gateway_pin"]
 
-        _LOGGER.debug("ZeroConf discovery detected gateway %s", obfuscate_id(gateway_id))
+        _LOGGER.debug(
+            "ZeroConf discovery detected gateway %s", obfuscate_id(gateway_id)
+        )
 
         if self._gateway_already_configured(gateway_id):
             _LOGGER.debug("Gateway %s is already configured", obfuscate_id(gateway_id))

--- a/custom_components/tahoma/manifest.json
+++ b/custom_components/tahoma/manifest.json
@@ -14,6 +14,7 @@
   ],
   "issue_tracker": "https://github.com/imicknl/ha-tahoma/issues",
   "version": "2.11",
+  "zeroconf": ["_kizbox._tcp.local."],
   "dhcp": [
     {
       "hostname": "gateway*",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pytest-homeassistant-custom-component==0.5.3
 # required for DHCP discovery test
 scapy==2.4.5
 aiodiscover==1.4.5
+zeroconf

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@ pytest-homeassistant-custom-component==0.5.3
 # required for DHCP discovery test
 scapy==2.4.5
 aiodiscover==1.4.5
-zeroconf
+zeroconf==0.38.1


### PR DESCRIPTION
Hello,

I've added the support for discovering the overkiz box by ZeroConf.

The entry is: _kizbox._tcp.local.

There's a `properties` attribute which contain directly the gateway ref (aka `gateway_pin`).


<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/717"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

