### PR TITLE
Fix URL for event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can subscribe to the `overkiz.event` event type in Developer Tools/Events in
 }
 ```
 
-You can find the list of available failure_type [here](https://github.com/iMicknl/python-overkiz-api/blob/master/pyoverkiz/enums.py#L118).
+You can find the list of available failure_type [here](https://github.com/iMicknl/python-overkiz-api/blob/main/pyoverkiz/enums/general.py).
 
 ### Enable debug logging
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can subscribe to the `overkiz.event` event type in Developer Tools/Events in
 }
 ```
 
-You can find the list of available failure_type [here](https://github.com/iMicknl/python-overkiz-api/blob/main/pyoverkiz/enums/general.py).
+You can find the list of available failure_type [here](https://github.com/iMicknl/python-overkiz-api/blob/main/pyoverkiz/enums/general.py#L34).
 
 ### Enable debug logging
 


### PR DESCRIPTION
The URL in the readme is out of date, this resolves it.

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/725"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

