### PR TITLE
Don't load integration if core integration is configured

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if await _block_if_core_is_configured(hass, entry):
         raise ConfigEntryNotReady(
-            "You cannot use overkiz from core and the custom component at the same time."
+            "You cannot use Overkiz from core and custom component at the same time."
         )
 
     # To allow users with multiple accounts/hubs, we create a new session so they have separate cookies

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -48,6 +48,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     password = entry.data[CONF_PASSWORD]
     server = SUPPORTED_SERVERS[entry.data[CONF_HUB]]
 
+    if await _block_if_core_is_configured(hass, entry):
+        raise ConfigEntryNotReady(
+            "You cannot use overkiz from core and the custom component at the same time."
+        )
+
     # To allow users with multiple accounts/hubs, we create a new session so they have separate cookies
     session = async_create_clientsession(hass)
     client = OverkizClient(
@@ -203,3 +208,16 @@ async def write_execution_history_to_log(client: OverkizClient):
 def log_device(message: str, device: Device) -> None:
     """Log device information."""
     _LOGGER.debug("%s (%s)", message, device)
+
+
+async def _block_if_core_is_configured(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    overkiz_config_entries = hass.config_entries.async_entries("overkiz")
+
+    for overkiz_entry in overkiz_config_entries:
+        if (
+            entry.data[CONF_USERNAME] == overkiz_entry.data[CONF_USERNAME]
+            and entry.data[CONF_HUB] == overkiz_entry.data[CONF_HUB]
+        ):
+            return True
+
+    return False


### PR DESCRIPTION
<img width="998" alt="Screen Shot 2022-01-26 at 17 59 50" src="https://user-images.githubusercontent.com/1424596/151210874-9263bceb-42be-4711-aca1-c5505d7a96ca.png">

Not perfect since it will only check a boot / reload, however I think that would be good enough for now. Let's make sure that users don't configure both integrations.

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

