### PR TITLE
feat: Atlantic/Sauter Guelma DWH support

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -77,6 +77,13 @@ SENSOR_DESCRIPTIONS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     OverkizSensorDescription(
+        key=OverkizState.CORE_REMAINING_HOT_WATER,
+        name="Remaining Hot Water Volume",
+        icon="mdi:water",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    OverkizSensorDescription(
         key=OverkizState.CORE_WATER_CONSUMPTION,
         name="Water Consumption",
         icon="mdi:water",
@@ -106,6 +113,13 @@ SENSOR_DESCRIPTIONS = [
     OverkizSensorDescription(
         key=OverkizState.IO_MIDDLE_WATER_TEMPERATURE,
         name="Middle Water Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    OverkizSensorDescription(
+        key=OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE,
+        name="Middle Water Temperature",
+        native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/custom_components/tahoma/water_heater.py
+++ b/custom_components/tahoma/water_heater.py
@@ -9,13 +9,21 @@ from .const import DOMAIN
 from .water_heater_devices.domestic_hot_water_production import (
     DomesticHotWaterProduction,
 )
+from .water_heater_devices.domestic_hot_water_production_sauter_guelma import (
+    DomesticHotWaterProductionSauterGUELMA,
+)
 from .water_heater_devices.hitachi_dhw import HitachiDHW
+from pyoverkiz.enums import OverkizState
 
 TYPE = {
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: DomesticHotWaterProduction,
     UIWidget.HITACHI_DHW: HitachiDHW,
+    UIWidget.DOMESTIC_HOT_WATER_PRODUCTION + "SauterGUELMA": DomesticHotWaterProductionSauterGUELMA
 }
 
+def device_type(device):
+    device_full_name = device.widget + device.states.get(OverkizState.CORE_MANUFACTURER_NAME).value + device.states.get(OverkizState.CORE_NAME).value
+    return device_full_name if device_full_name in TYPE else device.widget
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -31,7 +39,7 @@ async def async_setup_entry(
     ]
 
     entities = [
-        TYPE[device.widget](device.device_url, coordinator)
+        TYPE[device_type(device)](device.device_url, coordinator)
         for device in water_heater_devices
         if device.widget in TYPE
     ]

--- a/custom_components/tahoma/water_heater.py
+++ b/custom_components/tahoma/water_heater.py
@@ -3,7 +3,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import UIWidget
+from pyoverkiz.enums import OverkizState, UIWidget
 
 from .const import DOMAIN
 from .water_heater_devices.domestic_hot_water_production import (
@@ -13,17 +13,22 @@ from .water_heater_devices.domestic_hot_water_production_sauter_guelma import (
     DomesticHotWaterProductionSauterGUELMA,
 )
 from .water_heater_devices.hitachi_dhw import HitachiDHW
-from pyoverkiz.enums import OverkizState
 
 TYPE = {
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: DomesticHotWaterProduction,
     UIWidget.HITACHI_DHW: HitachiDHW,
-    UIWidget.DOMESTIC_HOT_WATER_PRODUCTION + "SauterGUELMA": DomesticHotWaterProductionSauterGUELMA
+    UIWidget.DOMESTIC_HOT_WATER_PRODUCTION
+    + "SauterGUELMA": DomesticHotWaterProductionSauterGUELMA
 }
 
 def device_type(device):
-    device_full_name = device.widget + device.states.get(OverkizState.CORE_MANUFACTURER_NAME).value + device.states.get(OverkizState.CORE_NAME).value
+    device_full_name = (
+        device.widget
+        + device.states.get(OverkizState.CORE_MANUFACTURER_NAME).value
+        + device.states.get(OverkizState.CORE_NAME).value
+    )
     return device_full_name if device_full_name in TYPE else device.widget
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/tahoma/water_heater.py
+++ b/custom_components/tahoma/water_heater.py
@@ -18,10 +18,12 @@ TYPE = {
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: DomesticHotWaterProduction,
     UIWidget.HITACHI_DHW: HitachiDHW,
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION
-    + "SauterGUELMA": DomesticHotWaterProductionSauterGUELMA
+    + "SauterGUELMA": DomesticHotWaterProductionSauterGUELMA,
 }
 
+
 def device_type(device):
+    """Build a device type from ui.widget and device properties."""
     device_full_name = (
         device.widget
         + device.states.get(OverkizState.CORE_MANUFACTURER_NAME).value

--- a/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
+++ b/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
@@ -1,0 +1,72 @@
+
+"""Support for DomesticHotWaterProduction."""
+import logging
+from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
+from homeassistant.components.water_heater import (
+    STATE_ECO,
+    SUPPORT_AWAY_MODE,
+    SUPPORT_OPERATION_MODE,
+    WaterHeaterEntity,
+)
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from .domestic_hot_water_production import (
+    DomesticHotWaterProduction
+)
+
+STATE_MANUAL = "manual"
+STATE_AUTO = "auto"
+
+OVERKIZ_TO_OPERATION_MODE = {
+    OverkizCommandParam.MANUAL_ECO_ACTIVE: STATE_ECO,
+    OverkizCommandParam.MANUAL_ECO_INACTIVE: STATE_MANUAL,
+    OverkizCommandParam.AUTO_MODE: STATE_AUTO
+}
+
+OPERATION_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_OPERATION_MODE.items()}
+
+class DomesticHotWaterProductionSauterGUELMA(DomesticHotWaterProduction):
+    """Representation of a DomesticHotWaterProductionSauterGUELMA Water Heater."""
+
+    _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ]
+
+    _attr_supported_features = (
+            SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE
+        )
+    _attr_temperature_unit = TEMP_CELSIUS
+
+    def __init__(self, device_url, coordinator):
+        super().__init__(device_url, coordinator)
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. eco, electric, performance, ..."""
+        return OVERKIZ_TO_OPERATION_MODE[
+            self.executor.select_state(OverkizState.MODBUSLINK_DHW_MODE)
+        ]
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self.executor.select_state(OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE)
+
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return (
+            self.executor.select_state(OverkizState.MODBUSLINK_DHW_ABSENCE_MODE)
+                == OverkizCommandParam.ON
+            )
+
+    async def async_turn_away_mode_on(self):
+        """Turn away mode on."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_ABSENCE_MODE, OverkizCommandParam.ON
+        )
+
+    async def async_turn_away_mode_off(self):
+        """Turn away mode off."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_ABSENCE_MODE, OverkizCommandParam.OFF
+        )

--- a/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
+++ b/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
@@ -1,4 +1,3 @@
-
 """Support for DomesticHotWaterProduction."""
 
 from homeassistant.components.water_heater import (
@@ -32,7 +31,7 @@ class DomesticHotWaterProductionSauterGUELMA(DomesticHotWaterProduction):
     _attr_temperature_unit = TEMP_CELSIUS
 
     def __init__(self, device_url, coordinator):
-        """Initialize DomesticHotWaterProductionSauterGUELMA"""
+        """Initialize DomesticHotWaterProductionSauterGUELMA."""
         super().__init__(device_url, coordinator)
 
     @property

--- a/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
+++ b/custom_components/tahoma/water_heater_devices/domestic_hot_water_production_sauter_guelma.py
@@ -1,19 +1,15 @@
 
 """Support for DomesticHotWaterProduction."""
-import logging
-from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
+
 from homeassistant.components.water_heater import (
     STATE_ECO,
     SUPPORT_AWAY_MODE,
     SUPPORT_OPERATION_MODE,
-    WaterHeaterEntity,
 )
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import TEMP_CELSIUS
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
-from .domestic_hot_water_production import (
-    DomesticHotWaterProduction
-)
+from .domestic_hot_water_production import DomesticHotWaterProduction
 
 STATE_MANUAL = "manual"
 STATE_AUTO = "auto"
@@ -21,22 +17,22 @@ STATE_AUTO = "auto"
 OVERKIZ_TO_OPERATION_MODE = {
     OverkizCommandParam.MANUAL_ECO_ACTIVE: STATE_ECO,
     OverkizCommandParam.MANUAL_ECO_INACTIVE: STATE_MANUAL,
-    OverkizCommandParam.AUTO_MODE: STATE_AUTO
+    OverkizCommandParam.AUTO_MODE: STATE_AUTO,
 }
 
 OPERATION_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_OPERATION_MODE.items()}
+
 
 class DomesticHotWaterProductionSauterGUELMA(DomesticHotWaterProduction):
     """Representation of a DomesticHotWaterProductionSauterGUELMA Water Heater."""
 
     _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ]
 
-    _attr_supported_features = (
-            SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE
-        )
+    _attr_supported_features = SUPPORT_OPERATION_MODE | SUPPORT_AWAY_MODE
     _attr_temperature_unit = TEMP_CELSIUS
 
     def __init__(self, device_url, coordinator):
+        """Initialize DomesticHotWaterProductionSauterGUELMA"""
         super().__init__(device_url, coordinator)
 
     @property
@@ -49,15 +45,17 @@ class DomesticHotWaterProductionSauterGUELMA(DomesticHotWaterProduction):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self.executor.select_state(OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE)
+        return self.executor.select_state(
+            OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE
+        )
 
     @property
     def is_away_mode_on(self):
         """Return true if away mode is on."""
         return (
             self.executor.select_state(OverkizState.MODBUSLINK_DHW_ABSENCE_MODE)
-                == OverkizCommandParam.ON
-            )
+            == OverkizCommandParam.ON
+        )
 
     async def async_turn_away_mode_on(self):
         """Turn away mode on."""


### PR DESCRIPTION
Hi dear author,

I'm currently working on integrating a Sauter DHW which requires some additions to your project.
This DHW is derived from the Atlantic DomesticWaterHeater but with different states & operating modes.

I tried to implement a simple way to support any derived equipment models (Atlantic Group is known for OEM equipment) without relying to much on pythonic introspection and retaining as much as possible the current software architecture.

This PR relies on https://github.com/iMicknl/python-overkiz-api/pull/352 to be functional

Best,
R.


<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/743"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

