### PR TITLE
feat: Atlantic DHWP MLB support

### DIFF
--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -77,6 +77,13 @@ SENSOR_DESCRIPTIONS = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     OverkizSensorDescription(
+        key=OverkizState.CORE_REMAINING_HOT_WATER,
+        name="Remaining Hot Water Volume",
+        icon="mdi:water",
+        native_unit_of_measurement=VOLUME_LITERS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    OverkizSensorDescription(
         key=OverkizState.CORE_WATER_CONSUMPTION,
         name="Water Consumption",
         icon="mdi:water",
@@ -106,6 +113,13 @@ SENSOR_DESCRIPTIONS = [
     OverkizSensorDescription(
         key=OverkizState.IO_MIDDLE_WATER_TEMPERATURE,
         name="Middle Water Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    OverkizSensorDescription(
+        key=OverkizState.MODBUSLINK_MIDDLE_WATER_TEMPERATURE,
+        name="Middle Water Temperature",
+        native_unit_of_measurement=TEMP_CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
Hi,

This PR is a rework of https://github.com/iMicknl/ha-tahoma/pull/743 which is now more aligned with project coding standards & architecture.
Sauter GUELMA specifics are dropped in favor of a more generic MBL component (for modbuslink I guess).

NB: .value change is required to have the proper label displayed in Lovelace UI, otherwise the full enum label is displayed 
e.g "OverkizCommandParam.AUTO" instead of "auto"


<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/746"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

