### PR TITLE
Import HA isort configuration

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -7,6 +7,17 @@ from dataclasses import dataclass
 import logging
 
 from aiohttp import ClientError, ServerDisconnectedError
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.const import SUPPORTED_SERVERS
+from pyoverkiz.exceptions import (
+    BadCredentialsException,
+    InvalidCommandException,
+    MaintenanceException,
+    TooManyRequestsException,
+)
+from pyoverkiz.models import Command, Device, Scenario
+import voluptuous as vol
+
 from homeassistant.config_entries import (
     SOURCE_DHCP,
     SOURCE_USER,
@@ -22,16 +33,6 @@ from homeassistant.helpers import (
     service,
 )
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from pyoverkiz.client import OverkizClient
-from pyoverkiz.const import SUPPORTED_SERVERS
-from pyoverkiz.exceptions import (
-    BadCredentialsException,
-    InvalidCommandException,
-    MaintenanceException,
-    TooManyRequestsException,
-)
-from pyoverkiz.models import Command, Device, Scenario
-import voluptuous as vol
 
 from .const import (
     CONF_HUB,

--- a/custom_components/tahoma/binary_sensor.py
+++ b/custom_components/tahoma/binary_sensor.py
@@ -1,6 +1,9 @@
 """Support for Overkiz binary sensors."""
 from __future__ import annotations
 
+from pyoverkiz.enums import OverkizCommandParam, OverkizState
+
+from custom_components.tahoma import HomeAssistantOverkizData
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -8,9 +11,6 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizCommandParam, OverkizState
-
-from custom_components.tahoma import HomeAssistantOverkizData
 
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizBinarySensorDescription, OverkizDescriptiveEntity

--- a/custom_components/tahoma/climate.py
+++ b/custom_components/tahoma/climate.py
@@ -1,9 +1,10 @@
 """Support for Overkiz climate devices."""
+from pyoverkiz.enums import UIWidget
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import UIWidget
 
 from . import HomeAssistantOverkizData
 from .climate_devices.atlantic_electrical_heater import AtlanticElectricalHeater

--- a/custom_components/tahoma/climate_devices/atlantic_electrical_heater.py
+++ b/custom_components/tahoma/climate_devices/atlantic_electrical_heater.py
@@ -1,6 +1,8 @@
 """Support for Atlantic Electrical Heater."""
 from typing import Optional
 
+from pyoverkiz.enums import OverkizState
+
 from homeassistant.components.climate import (
     HVAC_MODE_OFF,
     SUPPORT_PRESET_MODE,
@@ -13,7 +15,6 @@ from homeassistant.components.climate.const import (
     PRESET_NONE,
 )
 from homeassistant.const import TEMP_CELSIUS
-from pyoverkiz.enums import OverkizState
 
 from ..entity import OverkizEntity
 

--- a/custom_components/tahoma/climate_devices/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/custom_components/tahoma/climate_devices/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Optional
 
+from pyoverkiz.enums import OverkizCommand, OverkizState
+
 from homeassistant.components.climate import (
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
@@ -24,7 +26,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_state_change
-from pyoverkiz.enums import OverkizCommand, OverkizState
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity

--- a/custom_components/tahoma/climate_devices/atlantic_electrical_towel_dryer.py
+++ b/custom_components/tahoma/climate_devices/atlantic_electrical_towel_dryer.py
@@ -1,6 +1,8 @@
 """Support for Atlantic Electrical Towel Dryer."""
 from typing import Optional
 
+from pyoverkiz.enums import OverkizState
+
 from homeassistant.components.climate import (
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
@@ -13,7 +15,6 @@ from homeassistant.components.climate.const import (
     PRESET_NONE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from pyoverkiz.enums import OverkizState
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity

--- a/custom_components/tahoma/climate_devices/hitachi_air_to_air_heat_pump.py
+++ b/custom_components/tahoma/climate_devices/hitachi_air_to_air_heat_pump.py
@@ -1,6 +1,8 @@
 """Support for HitachiAirToAirHeatPump."""
 from typing import Any, Dict, List, Optional
 
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -24,7 +26,6 @@ from homeassistant.components.climate.const import (
     SWING_VERTICAL,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from ..entity import OverkizEntity
 

--- a/custom_components/tahoma/climate_devices/somfy_heating_temperature_interface.py
+++ b/custom_components/tahoma/climate_devices/somfy_heating_temperature_interface.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Optional
 
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.climate import SUPPORT_PRESET_MODE, ClimateEntity
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
@@ -15,7 +17,6 @@ from homeassistant.components.climate.const import (
     PRESET_NONE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity

--- a/custom_components/tahoma/climate_devices/stateless_exterior_heating.py
+++ b/custom_components/tahoma/climate_devices/stateless_exterior_heating.py
@@ -1,10 +1,11 @@
 """Support for Stateless Exterior Heating device."""
 import logging
 
+from pyoverkiz.enums import OverkizCommand
+
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODE_OFF
 from homeassistant.const import TEMP_CELSIUS
-from pyoverkiz.enums import OverkizCommand
 
 from ..entity import OverkizEntity
 

--- a/custom_components/tahoma/config_flow.py
+++ b/custom_components/tahoma/config_flow.py
@@ -5,12 +5,6 @@ import logging
 from typing import Any, cast
 
 from aiohttp import ClientError
-from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.exceptions import (
@@ -20,6 +14,13 @@ from pyoverkiz.exceptions import (
 )
 from pyoverkiz.models import obfuscate_id
 import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import dhcp, zeroconf
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_HUB, DEFAULT_HUB, DOMAIN
 

--- a/custom_components/tahoma/const.py
+++ b/custom_components/tahoma/const.py
@@ -3,8 +3,9 @@ from datetime import timedelta
 import logging
 from typing import Final
 
-from homeassistant.const import Platform
 from pyoverkiz.enums import UIClass, UIWidget
+
+from homeassistant.const import Platform
 
 DOMAIN: Final = "tahoma"
 LOGGER: logging.Logger = logging.getLogger(__package__)

--- a/custom_components/tahoma/coordinator.py
+++ b/custom_components/tahoma/coordinator.py
@@ -5,11 +5,6 @@ from datetime import timedelta
 import logging
 
 from aiohttp import ServerDisconnectedError
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.decorator import Registry
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import EventName, ExecutionState
 from pyoverkiz.exceptions import (
@@ -19,6 +14,12 @@ from pyoverkiz.exceptions import (
     TooManyRequestsException,
 )
 from pyoverkiz.models import Device, Event, Place
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.decorator import Registry
 
 from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
 

--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -1,9 +1,10 @@
 """Support for Overkiz covers - shutters etc."""
+from pyoverkiz.enums import UIClass
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import UIClass
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/cover_entities/awning.py
+++ b/custom_components/tahoma/cover_entities/awning.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from pyoverkiz.enums import OverkizCommand, OverkizState
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DEVICE_CLASS_AWNING,
@@ -11,7 +13,6 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
 )
-from pyoverkiz.enums import OverkizCommand, OverkizState
 
 from .generic_cover import COMMANDS_STOP, OverkizGenericCover
 

--- a/custom_components/tahoma/cover_entities/generic_cover.py
+++ b/custom_components/tahoma/cover_entities/generic_cover.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.cover import (
     ATTR_TILT_POSITION,
     SUPPORT_CLOSE_TILT,
@@ -12,7 +14,6 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverEntity,
 )
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from ..entity import OverkizEntity
 

--- a/custom_components/tahoma/cover_entities/vertical_cover.py
+++ b/custom_components/tahoma/cover_entities/vertical_cover.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, Union, cast
 
+from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DEVICE_CLASS_AWNING,
@@ -17,7 +19,6 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
 )
-from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
 
 from .generic_cover import COMMANDS_STOP, OverkizGenericCover
 

--- a/custom_components/tahoma/entity.py
+++ b/custom_components/tahoma/entity.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from pyoverkiz.enums import OverkizAttribute, OverkizCommandParam, OverkizState
+from pyoverkiz.models import Device
+
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from pyoverkiz.enums import OverkizAttribute, OverkizCommandParam, OverkizState
-from pyoverkiz.models import Device
 
 from .const import DOMAIN
 from .coordinator import OverkizDataUpdateCoordinator

--- a/custom_components/tahoma/light.py
+++ b/custom_components/tahoma/light.py
@@ -1,4 +1,6 @@
 """Support for Overkiz light devices."""
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_EFFECT,
@@ -13,7 +15,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.color as color_util
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/lock.py
+++ b/custom_components/tahoma/lock.py
@@ -1,10 +1,11 @@
 """Support for Overkiz lock."""
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/number.py
+++ b/custom_components/tahoma/number.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
+from pyoverkiz.enums import OverkizCommand, OverkizState
+
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizCommand, OverkizState
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES

--- a/custom_components/tahoma/scene.py
+++ b/custom_components/tahoma/scene.py
@@ -1,12 +1,13 @@
 """Support for Overkiz scenes."""
 from typing import Any
 
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.models import Scenario
+
 from homeassistant.components.scene import DOMAIN as SCENE, Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.client import OverkizClient
-from pyoverkiz.models import Scenario
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/select.py
+++ b/custom_components/tahoma/select.py
@@ -1,12 +1,13 @@
 """Support for Overkiz select devices."""
 from __future__ import annotations
 
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES

--- a/custom_components/tahoma/sensor.py
+++ b/custom_components/tahoma/sensor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -24,7 +26,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES

--- a/custom_components/tahoma/siren.py
+++ b/custom_components/tahoma/siren.py
@@ -1,4 +1,7 @@
 """Support for Overkiz sirens."""
+from pyoverkiz.enums import OverkizState
+from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam
+
 from homeassistant.components.siren import SirenEntity
 from homeassistant.components.siren.const import (
     ATTR_DURATION,
@@ -10,8 +13,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import OverkizState
-from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -1,6 +1,8 @@
 """Support for Overkiz switches."""
 from typing import Any
 
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.switch import DEVICE_CLASS_SWITCH, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -8,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/water_heater.py
+++ b/custom_components/tahoma/water_heater.py
@@ -1,9 +1,10 @@
 """Support for Overkiz water heater devices."""
+from pyoverkiz.enums import UIWidget
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyoverkiz.enums import UIWidget
 
 from . import HomeAssistantOverkizData
 from .const import DOMAIN

--- a/custom_components/tahoma/water_heater_devices/domestic_hot_water_production.py
+++ b/custom_components/tahoma/water_heater_devices/domestic_hot_water_production.py
@@ -1,4 +1,6 @@
 """Support for DomesticHotWaterProduction."""
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
 from homeassistant.components.water_heater import (
     STATE_ECO,
@@ -7,7 +9,6 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from ..entity import OverkizEntity
 

--- a/custom_components/tahoma/water_heater_devices/hitachi_dhw.py
+++ b/custom_components/tahoma/water_heater_devices/hitachi_dhw.py
@@ -1,4 +1,6 @@
 """Support for HitachiDHW."""
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
 from homeassistant.components.climate.const import SUPPORT_TARGET_TEMPERATURE
 from homeassistant.components.water_heater import (
     STATE_HIGH_DEMAND,
@@ -11,7 +13,6 @@ from homeassistant.const import (
     STATE_OFF,
     TEMP_CELSIUS,
 )
-from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from ..entity import OverkizEntity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+target-version = ["py38"]
+exclude = 'generated'
+
+[tool.isort]
+# https://github.com/PyCQA/isort/wiki/isort-Settings
+profile = "black"
+# will group `import x` and `from x import` of the same module.
+force_sort_within_sections = true
+known_first_party = [
+    "homeassistant",
+    "tests",
+]
+forced_separate = [
+    "tests",
+]
+combine_as_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+max-complexity = 25
 doctests = True
 # To work with Black
-max-line-length = 88
 # E501: line too long
 # W503: Line break occurred before a binary operator
 # E203: Whitespace before ':'
@@ -14,22 +14,4 @@ ignore =
     E203,
     D202,
     W504
-
-[isort]
-# https://github.com/timothycrosley/isort
-# https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_first_party = custom_components.tahoma, tests
-combine_as_imports = true
+noqa-require-code = True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 from unittest.mock import Mock, patch
 
 from aiohttp import ClientError
-from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import dhcp
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
-from homeassistant.core import HomeAssistant
 from pyoverkiz.exceptions import (
     BadCredentialsException,
     MaintenanceException,
@@ -20,6 +16,10 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from custom_components.tahoma import config_flow
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import dhcp
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.core import HomeAssistant
 
 TEST_EMAIL = "test@testdomain.com"
 TEST_EMAIL2 = "test@testdomain.nl"


### PR DESCRIPTION
During the backport of the Core, I notice some difference on the import order. 
So I copied HA configuration to have the same output here. 
It will ease the backport.

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/760"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

