### PR TITLE
Reintroduce low speed feature

### DIFF
--- a/custom_components/tahoma/cover.py
+++ b/custom_components/tahoma/cover.py
@@ -1,5 +1,5 @@
 """Support for Overkiz covers - shutters etc."""
-from pyoverkiz.enums import UIClass
+from pyoverkiz.enums import OverkizCommand, UIClass
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -29,6 +29,13 @@ async def async_setup_entry(
         VerticalCover(device.device_url, data.coordinator)
         for device in data.platforms[Platform.COVER]
         if device.ui_class != UIClass.AWNING
+    ]
+
+    entities += [
+        VerticalCover(device.device_url, data.coordinator, low_speed=True)
+        for device in data.platforms[Platform.COVER]
+        if device.ui_class != UIClass.AWNING
+        and OverkizCommand.SET_CLOSURE_AND_LINEAR_SPEED in device.definition.commands
     ]
 
     async_add_entities(entities)

--- a/custom_components/tahoma/cover_entities/vertical_cover.py
+++ b/custom_components/tahoma/cover_entities/vertical_cover.py
@@ -5,6 +5,7 @@ from typing import Any, Union, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizState, UIClass, UIWidget
 
+from custom_components.tahoma.coordinator import OverkizDataUpdateCoordinator
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DEVICE_CLASS_AWNING,
@@ -41,6 +42,19 @@ OVERKIZ_DEVICE_TO_DEVICE_CLASS = {
 
 class VerticalCover(OverkizGenericCover):
     """Representation of an Overkiz vertical cover."""
+
+    def __init__(
+        self,
+        device_url: str,
+        coordinator: OverkizDataUpdateCoordinator,
+        low_speed: bool = False,
+    ):
+        """Initialize the device."""
+        super().__init__(device_url, coordinator)
+        self.low_speed = low_speed
+        if self.low_speed:
+            self._attr_name = f"{self._attr_name} Low Speed"
+            self._attr_unique_id = f"{self._attr_unique_id}_low_speed"
 
     @property
     def supported_features(self) -> int:
@@ -97,15 +111,33 @@ class VerticalCover(OverkizGenericCover):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        position = 100 - kwargs.get(ATTR_POSITION, 0)
-        await self.executor.async_execute_command(OverkizCommand.SET_CLOSURE, position)
+        if self.low_speed:
+            await self.async_set_cover_position_low_speed(**kwargs)
+        else:
+            position = 100 - kwargs.get(ATTR_POSITION, 0)
+            await self.executor.async_execute_command(
+                OverkizCommand.SET_CLOSURE, position
+            )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        if command := self.executor.select_command(*COMMANDS_OPEN):
+        if self.low_speed:
+            await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 100})
+
+        elif command := self.executor.select_command(*COMMANDS_OPEN):
             await self.executor.async_execute_command(command)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        if command := self.executor.select_command(*COMMANDS_CLOSE):
+        if self.low_speed:
+            await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 0})
+        elif command := self.executor.select_command(*COMMANDS_CLOSE):
             await self.executor.async_execute_command(command)
+
+    async def async_set_cover_position_low_speed(self, **kwargs):
+        """Move the cover to a specific position with a low speed."""
+        position = 100 - kwargs.get(ATTR_POSITION, 0)
+
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_CLOSURE_AND_LINEAR_SPEED, position, "lowspeed"
+        )

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -17,6 +17,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData

--- a/custom_components/tahoma/switch.py
+++ b/custom_components/tahoma/switch.py
@@ -17,7 +17,6 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData


### PR DESCRIPTION
This PR reintroduces the low speed feature supported by some covers.

As you can see, it’s not anymore the service nor the switch. IMO, bot would be rejected by the Core team:
 * Virtual entity are not allowed
 * Our service was based on a new feature flag (1024)

<a href="https://gitpod.io/#https://github.com/iMicknl/ha-tahoma/pull/763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

