### PR TITLE
Select correct coordinator for execute_command service

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -158,10 +158,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
         for entity_id in call.data.get("entity_id"):
-            entity = entity_registry.entities.get(entity_id)
+            registry_entry = entity_registry.entities.get(entity_id)
+            entity = [
+                e
+                for e in hass.data["entity_components"][registry_entry.domain].entities
+                if e.unique_id == registry_entry.unique_id
+            ][0]
 
             try:
-                await coordinator.client.execute_command(
+                await entity.coordinator.client.execute_command(
+
                     entity.unique_id,
                     Command(call.data.get("command"), call.data.get("args")),
                     "Home Assistant Service",

--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -167,7 +167,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             try:
                 await entity.coordinator.client.execute_command(
-
                     entity.unique_id,
                     Command(call.data.get("command"), call.data.get("args")),
                     "Home Assistant Service",


### PR DESCRIPTION
In case several hubs are registered, the service was called on the latest coordinator registered, which could thus be one not corresponding to the entity passed as argument. This fix allows to retrieve the coordinator attached to the given entity.

can relate to https://github.com/iMicknl/ha-tahoma/issues/167