### PR TITLE
Remove deprecated async_setup_platforms

### DIFF
--- a/custom_components/tahoma/__init__.py
+++ b/custom_components/tahoma/__init__.py
@@ -137,7 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ):
             log_device("Unsupported device detected", device)
 
-    hass.config_entries.async_setup_platforms(entry, SUPPORTED_PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
 
     device_registry = dr.async_get(hass)
 


### PR DESCRIPTION
Replace with `async_forward_entry_setups`.
Fixes #843.